### PR TITLE
✨ Add Time Format Extensions

### DIFF
--- a/lib/app/extensions/time_format_extension.dart
+++ b/lib/app/extensions/time_format_extension.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+extension TimeFormatExtension on TimeOfDay {
+  String get formatTime {
+    final time = DateTime.now();
+    return '${time.hour}:${time.minute}:${time.second}';
+  }
+
+  /// convert `24h` to `12h` format with `AM/PM` suffix
+  /// eg: 23:59:59 PM
+  ///
+  /// For example:
+  /// ```dart
+  /// final time = TimeOfDay(hour: 23, minute: 59, second: 59);
+  /// print(time.formatTime12h); // 11:59:59 PM
+  /// ```
+  ///
+  String get formatTime12h {
+    final time = DateTime.now();
+    return '${time.hour > 12 ? time.hour - 12 : time.hour == 0 ? 12 : time.hour}:${time.minute}:${time.second} ${time.hour > 12 ? 'PM' : 'AM'}';
+  }
+}


### PR DESCRIPTION
Add extension methods to format TimeOfDay in `24h` and `12h` formats with
`AM/PM` suffix. This allows for easier handling and display of time formats.

Co-authored-by: [Your Name] <your.email@example.com>