### PR TITLE
Fix typo in HomeScreen text

### DIFF
--- a/lib/presentation/views/home/home_screen.dart
+++ b/lib/presentation/views/home/home_screen.dart
@@ -15,7 +15,7 @@ class HomeScreen extends GetView<HomeController> {
       ),
       body: const Center(
         child: Text(
-          'HomeScreen',
+          'HomeScreenn',
           style: TextStyle(fontSize: 20),
         ),
       ),


### PR DESCRIPTION
Corrected a typo in the text displayed on the HomeScreen widget. The text now
reads 'HomeScreen' instead of 'HomeScreenn'.