### PR TITLE
✨ Add changeAppLocale extension method

### DIFF
--- a/lib/app/extensions/change_app_locale_extension.dart
+++ b/lib/app/extensions/change_app_locale_extension.dart
@@ -1,0 +1,16 @@
+import 'package:easy_localization/easy_localization.dart'
+    show BuildContextEasyLocalizationExtension;
+import 'package:flutter/material.dart' show BuildContext, Locale;
+import 'package:get/get.dart' show Get, GetNavigation;
+
+extension ChangeAppLocale on BuildContext {
+  void changeAppLocale(Locale locale) {
+    if (this.locale.languageCode == locale.languageCode &&
+        this.locale.countryCode == locale.countryCode) {
+      return;
+    }
+    setLocale(locale);
+    Get.updateLocale(locale);
+    return;
+  }
+}

--- a/lib/app/generated/keys.dart
+++ b/lib/app/generated/keys.dart
@@ -1,0 +1,5 @@
+// DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
+
+abstract class LocaleKeys {
+  static const title = 'title';
+}

--- a/lib/presentation/resource_manager/constants/supported_locales.dart
+++ b/lib/presentation/resource_manager/constants/supported_locales.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart' show Locale;
 
 abstract class SupportedLocales {
+  static const Locale englishUS = Locale('en', 'US');
+
+  static const Locale arabicEG = Locale('ar', 'EG');
+
   static const List<Locale> supportedLocales = [
-    Locale('ar', 'EG'),
-    Locale('en', 'US'),
+    arabicEG,
+    englishUS,
   ];
 
-  static const fallbackLocale = Locale('en', 'US');
+  static const fallbackLocale = englishUS;
 }

--- a/lib/presentation/views/home/home_screen.dart
+++ b/lib/presentation/views/home/home_screen.dart
@@ -1,7 +1,10 @@
+import 'package:control_system/app/extensions/change_app_locale_extension.dart';
+import 'package:control_system/app/generated/keys.dart';
 import 'package:control_system/domain/controllers/home_controller.dart';
+import 'package:control_system/presentation/resource_manager/constants/supported_locales.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:get/state_manager.dart';
+import 'package:get/get.dart';
 
 class HomeScreen extends GetView<HomeController> {
   const HomeScreen({super.key});
@@ -10,7 +13,7 @@ class HomeScreen extends GetView<HomeController> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('title').tr(),
+        title: const Text(LocaleKeys.title).tr(),
         centerTitle: true,
       ),
       body: Center(
@@ -18,7 +21,7 @@ class HomeScreen extends GetView<HomeController> {
           children: [
             TextButton(
               onPressed: () {
-                context.setLocale(const Locale('ar', 'EG'));
+                context.changeAppLocale(SupportedLocales.arabicEG);
               },
               child: const Text(
                 'العربية',
@@ -26,7 +29,7 @@ class HomeScreen extends GetView<HomeController> {
             ),
             TextButton(
               onPressed: () {
-                context.setLocale(const Locale('en', 'US'));
+                context.changeAppLocale(SupportedLocales.englishUS);
               },
               child: const Text(
                 'English',


### PR DESCRIPTION
Added a new extension method `changeAppLocale` to easily update and handle app locales in the `HomeScreen`.
Focused on supporting English (US) and Arabic (EG) locales for the app.