### PR TITLE
✨ Remove unused configurations in analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,6 @@
 include: package:flutter_lints/flutter.yaml
-
-analyzer:
-  errors:
-    constant_identifier_names: ignore
-  exclude:
-    - "/lib/app/generated/codegen_loader.g.dart"
+# analyzer:
+#   errors:
+#     constant_identifier_names: ignore
+#   exclude:
+#     - "/lib/app/generated/codegen_loader.g.dart"


### PR DESCRIPTION
Removed unused configurations in analysis_options.yaml to keep the file
clean and focused.