### PR TITLE
✨ Fix typo in Nunito Black font name

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   easy_sidemenu: ^0.6.0
   awesome_dialog: ^3.2.1
 
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -44,7 +43,7 @@ flutter:
           weight: 600
         - asset: assets/fonts/Nunito-Bold.ttf
           weight: 700
-        - asset: assets/fonts/Nunito-black.ttf
+        - asset: assets/fonts/Nunito-Black.ttf
           weight: 900
     - family: PlayfairDisplay
       fonts:


### PR DESCRIPTION
Adjusted asset reference in pubspec.yaml for the Nunito Black font file to correct typo in the file name.