### PR TITLE
✨ Fix typo in Schools Screen name

### DIFF
--- a/lib/presentation/views/schools/school_screen.dart
+++ b/lib/presentation/views/schools/school_screen.dart
@@ -9,7 +9,7 @@ class SchoolsScreen extends StatelessWidget {
     return BaseScreen(
       key: key,
       body: const Center(
-        child: Text("Schools Sreen"),
+        child: Text("Schools Screen"),
       ),
     );
   }


### PR DESCRIPTION
Updated the typo in the name of the Schools Screen to correct spelling.