### PR TITLE
✨ Add new ClassRoomsScreen view class

### DIFF
--- a/lib/presentation/views/class_rooms/class_rooms_screen.dart
+++ b/lib/presentation/views/class_rooms/class_rooms_screen.dart
@@ -1,0 +1,16 @@
+import 'package:control_system/presentation/views/base_screen.dart';
+import 'package:flutter/material.dart';
+
+class ClassRoomsScreen extends StatelessWidget {
+  const ClassRoomsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScreen(
+      key: key,
+      body: const Center(
+        child: Text("Class Rooms Screen"),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Added a new ClassRoomsScreen class that extends StatelessWidget and displays
the "Class Rooms Screen" text in the center of the screen using BaseScreen.