### PR TITLE
✨ Add SetDegreesScreen widget to handle setting degrees

### DIFF
--- a/lib/presentation/views/set_degrees/set_degrees_screen.dart
+++ b/lib/presentation/views/set_degrees/set_degrees_screen.dart
@@ -1,0 +1,16 @@
+import 'package:control_system/presentation/views/base_screen.dart';
+import 'package:flutter/material.dart';
+
+class SetDegreesScreen extends StatelessWidget {
+  const SetDegreesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScreen(
+      key: key,
+      body: const Center(
+        child: Text("Set Degrees Screen"),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This commit adds a new SetDegreesScreen widget to handle setting degrees in
the control system application. This widget extends StatelessWidget and renders
the screen content within a BaseScreen component.