### PR TITLE
✨ Update login form to check if context is mounted before navigating

### DIFF
--- a/lib/presentation/views/Login/widgets/login_form.dart
+++ b/lib/presentation/views/Login/widgets/login_form.dart
@@ -102,12 +102,16 @@ class LoginForm extends GetView<AuthController> {
                                     ? const CircularProgressIndicator()
                                     : ElevatedButton(
                                         onPressed: () async {
-                                        await  controller.login(emailController.text,
-                                              passwordController.text);
-                                           context.goNamed(
-                                            AppRoutesNamesAndPaths
-                                                .schoolsScreenName,
+                                          await controller.login(
+                                            emailController.text,
+                                            passwordController.text,
                                           );
+                                          !context.mounted
+                                              ? null
+                                              : context.goNamed(
+                                                  AppRoutesNamesAndPaths
+                                                      .schoolsScreenName,
+                                                );
                                         },
                                         child: const Text("Login"),
                                       ),


### PR DESCRIPTION
The LoginForm widget now checks if the context is mounted before navigating
to the schools screen after a successful login. This prevents potential
errors when navigating during widget disposal.