### PR TITLE
✨ Fix color inconsistency in ColorManager 🎨

### DIFF
--- a/lib/presentation/resource_manager/color_manager.dart
+++ b/lib/presentation/resource_manager/color_manager.dart
@@ -40,7 +40,7 @@ class ColorManager {
 
   static Color white = const Color(0xffffffff);
 
-  static Color black = Colors.white;
+  static Color black = Colors.black;
 
   static Color appbarColor = Colors.white;
   static Color appbarColorShadow = Colors.black;


### PR DESCRIPTION
Changed the 'black' color from `Colors.white` to `Colors.black` to ensure
consistency in the ColorManager class.