### PR TITLE
✨ Add exam room route and screen

### DIFF
--- a/lib/presentation/resource_manager/routes/app_go_router.dart
+++ b/lib/presentation/resource_manager/routes/app_go_router.dart
@@ -1,4 +1,5 @@
 import 'package:control_system/presentation/resource_manager/routes/app_routes_names_and_paths.dart';
+import 'package:control_system/presentation/views/class_rooms/widgets/exam_room.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
 
@@ -198,6 +199,16 @@ class AppGoRouter {
         name: AppRoutesNamesAndPaths.renderSeatScreenName,
         builder: (context, state) {
           return const RenderSeats();
+        },
+        onExit: (context, state) {
+          return true;
+        },
+      ),
+      GoRoute(
+        path: AppRoutesNamesAndPaths.examRoomScreenPath,
+        name: AppRoutesNamesAndPaths.examRoomScreenName,
+        builder: (context, state) {
+          return const ExamRoom();
         },
         onExit: (context, state) {
           return true;

--- a/lib/presentation/resource_manager/routes/app_routes_names_and_paths.dart
+++ b/lib/presentation/resource_manager/routes/app_routes_names_and_paths.dart
@@ -66,4 +66,8 @@ class AppRoutesNamesAndPaths {
   // renderSeatScreen
   static const String renderSeatScreenPath = '/render-seat';
   static const String renderSeatScreenName = 'Render Seat';
+
+  // examRoomScreen
+  static const String examRoomScreenPath = '/exam-room';
+  static const String examRoomScreenName = 'Exam Room';
 }

--- a/lib/presentation/views/class_rooms/widgets/exam_room.dart
+++ b/lib/presentation/views/class_rooms/widgets/exam_room.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+import '../../base_screen.dart';
+
+class ExamRoom extends StatelessWidget {
+  const ExamRoom({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScreen(body: Container());
+  }
+}


### PR DESCRIPTION
Added a new route and screen for the exam room in the app go router.
New route path is '/exam-room' and screen name is 'Exam Room'.
Included ExamRoom widget in class_rooms folder for exam room view.