### PR TITLE
✨ Fix typo in control mission screen filename

### DIFF
--- a/lib/presentation/views/index.dart
+++ b/lib/presentation/views/index.dart
@@ -5,7 +5,7 @@ export 'certificates/certificates_screen.dart';
 export 'class_rooms/class_rooms_screen.dart';
 export 'class_rooms/widgets/render_seat.dart';
 export 'cohort_settings/cohort_settings_screen.dart';
-export 'control_mission/control_mession_screen.dart';
+export 'control_mission/control_mission_screen.dart';
 export 'dashboard/dash_board_screen.dart';
 export 'home/home_screen.dart';
 export 'proctor/proctor_screen.dart';


### PR DESCRIPTION
Corrected the typo in the filename from 'control_mession_screen.dart' to 
'control_mission_screen.dart'.