### PR TITLE
✨ Update ResponseHandler to handle different response types

### DIFF
--- a/lib/Data/Network/response_handler.dart
+++ b/lib/Data/Network/response_handler.dart
@@ -4,12 +4,14 @@ import 'package:dio/dio.dart';
 import '../handlers/interfaces/response_interface.dart';
 import 'tools/failure_model.dart';
 
-class ResponseHandler<T extends ResponseInterface> {
-  T? data;
+class ResponseHandler<T extends ResponseInterface, R> {
+  T data;
 
-  Either<Failure, T> getResponse(Response<dynamic> response) {
-    if (response.statusCode == 200) {
-      return Right(data!.fromJson(response.data));
+  ResponseHandler({required this.data});
+
+  Either<Failure, R> getResponse(Response<dynamic> response) {
+    if (response.data['status'] == true) {
+      return Right(data.fromJson(response.data['data']));
     } else {
       return Left(Failure(response.statusCode ?? 0, response.data['message']));
     }

--- a/lib/domain/controllers/auth_controller.dart
+++ b/lib/domain/controllers/auth_controller.dart
@@ -33,14 +33,16 @@ class AuthController extends GetxController {
         "password": password,
       });
 
-      ResponseHandler<LoginResponseImplementationHandler> responseHandler =
-          ResponseHandler<LoginResponseImplementationHandler>();
-      Either<Failure, LoginResponseImplementationHandler> result =
-          responseHandler.getResponse(response.data['data']);
+      ResponseHandler<LoginResponseImplementationHandler, LoginResponse>
+          responseHandler =
+          ResponseHandler(data: LoginResponseImplementationHandler());
+      Either<Failure, LoginResponse> result =
+          responseHandler.getResponse(response);
+      debugPrint(result.toString());
       if (result.isRight()) {
         LoginResponseImplementationHandler loginResponse = result.foldRight(
             LoginResponseImplementationHandler(), (r, previous) => previous);
-        LoginResponse data = loginResponse.fromJson(response.data);
+        LoginResponse data = loginResponse.fromJson(response.data['data']);
         TokenModel tokenModel = TokenModel(
           aToken: data.accessToken!,
           rToken: data.refreshToken!,


### PR DESCRIPTION
Refactor ResponseHandler to take generic types to handle different response
data. Now, it can handle different response data types based on the
implementation.