### PR TITLE
✨ Update ResponseHandler generic type constraint

### DIFF
--- a/lib/Data/Network/response_handler.dart
+++ b/lib/Data/Network/response_handler.dart
@@ -1,10 +1,11 @@
+import 'package:control_system/Data/Models/base_model.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 
 import '../handlers/interfaces/response_interface.dart';
 import 'tools/failure_model.dart';
 
-class ResponseHandler<T extends ResponseInterface, R> {
+class ResponseHandler<T extends ResponseInterface, R extends BaseModel> {
   T data;
 
   ResponseHandler({required this.data});


### PR DESCRIPTION
Changed ResponseHandler generic type constraint to include R extending
BaseModel. This ensures that the ResponseHandler class can only accept
types that extend the BaseModel class, providing more specific typing
and ensuring consistency in data handling.