### PR TITLE
✨ Refactor request format for getResponse method

### DIFF
--- a/lib/Data/Network/response_handler.dart
+++ b/lib/Data/Network/response_handler.dart
@@ -11,13 +11,13 @@ class ResponseHandler<T> {
 
   final Dio _dio;
 
-  Future<Either<Failure, T>> getResponse(
-    String path,
-    T Function(Map<String, dynamic>) converter,
-    ReqTypeEnum type,
+  Future<Either<Failure, T>> getResponse({
+    required String path,
+    required T Function(Map<String, dynamic>) converter,
+    required ReqTypeEnum type,
     Map<String, dynamic>? params,
     Map<String, dynamic>? body,
-  ) async {
+  }) async {
     switch (type) {
       case ReqTypeEnum.GET:
         return await _get(path, converter, params, body);

--- a/lib/domain/controllers/auth_controller.dart
+++ b/lib/domain/controllers/auth_controller.dart
@@ -59,10 +59,14 @@ class AuthController extends GetxController {
     ResponseHandler<LoginResModel> responseHandler = ResponseHandler();
 
     Either<Failure, LoginResModel> response = await responseHandler.getResponse(
-        AuthLinks.login, LoginResModel.fromJson, ReqTypeEnum.POST, {
-      "userName": username,
-      "password": password,
-    });
+      path: AuthLinks.login,
+      converter: LoginResModel.fromJson,
+      type: ReqTypeEnum.POST,
+      body: {
+        "userName": username,
+        "password": password,
+      },
+    );
 
     response.fold(
         (l) => MyAwesomeDialogue(


### PR DESCRIPTION
Refactor the parameters for the getResponse method in response_handler.dart
and auth_controller.dart to use named parameters for better readability.