### PR TITLE
✨ Add Cohort Widget component

### DIFF
--- a/lib/presentation/views/cohort_settings/widgets/add_cohort_widget.dart
+++ b/lib/presentation/views/cohort_settings/widgets/add_cohort_widget.dart
@@ -1,0 +1,120 @@
+import 'dart:developer';
+
+import 'package:control_system/domain/controllers/cohorts_settings_controller.dart';
+import 'package:control_system/presentation/resource_manager/ReusableWidget/elevated_add_button.dart';
+import 'package:control_system/presentation/resource_manager/ReusableWidget/my_snak_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../resource_manager/ReusableWidget/elevated_back_button.dart';
+import '../../../resource_manager/color_manager.dart';
+import '../../../resource_manager/styles_manager.dart';
+
+class AddCohortWidget extends StatelessWidget {
+  const AddCohortWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    TextEditingController editingController = TextEditingController();
+    return GetBuilder<CohortsSettingsController>(
+      builder: (controller) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              "Add new Cohort",
+              style: nunitoRegular.copyWith(
+                color: ColorManager.bgSideMenu,
+                fontSize: 25,
+              ),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+            TextFormField(
+              cursorColor: ColorManager.bgSideMenu,
+              style: nunitoRegular.copyWith(
+                  fontSize: 14, color: ColorManager.bgSideMenu),
+              decoration: InputDecoration(
+                hintText: "Cohort name",
+                hintStyle: nunitoRegular.copyWith(
+                  fontSize: 14,
+                  color: ColorManager.bgSideMenu,
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                errorBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                disabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(5),
+                ),
+              ),
+              controller: editingController,
+              onChanged: (value) {
+                int found = controller.cohorts.indexWhere(
+                  (p0) => p0.name == value,
+                );
+                if (found > -1) {
+                  log('founded');
+                }
+              },
+            ),
+            const SizedBox(
+              height: 20,
+            ),
+            Row(
+              children: [
+                const Expanded(
+                  child: ElevatedBackButton(),
+                ),
+                const SizedBox(
+                  width: 20,
+                ),
+                Expanded(
+                  child: Expanded(
+                    child: ElevatedAddButton(
+                      onPressed: () async {
+                        if (editingController.text != "") {
+                          int found = controller.cohorts.indexWhere(
+                            (p0) => p0.name == editingController.text,
+                          );
+                          if (found > -1) {
+                            log('founded');
+                          } else {
+                            controller
+                                .addnewCohort(editingController.text)
+                                .then(
+                              (value) {
+                                value
+                                    ? {
+                                        context.pop(),
+                                        MyFlashBar.showSuccess(
+                                          "The Cohort has been added successfully",
+                                          "Success",
+                                        ).show(context),
+                                      }
+                                    : null;
+                              },
+                            );
+                          }
+                        } else {
+                          MyFlashBar.showError("enter cohort name", "Error");
+                        }
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Added a new widget to allow users to add a new cohort. The widget includes
input fields for cohort name and buttons to add the cohort. The functionality
includes validation and error handling for adding a new cohort.

Co-authored-by: [author]