### PR TITLE
Refactor ElevatedBackButton and reset class room controller on back button press

### DIFF
--- a/lib/presentation/resource_manager/ReusableWidget/elevated_back_button.dart
+++ b/lib/presentation/resource_manager/ReusableWidget/elevated_back_button.dart
@@ -5,12 +5,15 @@ import '../color_manager.dart';
 import '../styles_manager.dart';
 
 class ElevatedBackButton extends StatelessWidget {
-  const ElevatedBackButton({super.key});
+  const ElevatedBackButton({super.key, this.onPressed});
+
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
+        onPressed?.call();
         Get.back();
       },
       child: Container(

--- a/lib/presentation/views/class_room_seats/widgets/render_seat_widget.dart
+++ b/lib/presentation/views/class_room_seats/widgets/render_seat_widget.dart
@@ -54,13 +54,13 @@ class RendarSeats extends StatelessWidget {
                                 ),
                                 Positioned(
                                   //       width: 0,
-                                  top: 25,
+                                  top: 40,
                                   //   left: 0,
-                                  right: (size.width * 0.1) / 2 - 10,
+                                  right: (size.width * 0.085) / 2,
                                   child: Text(
                                     controller.count.toString(),
-                                    style: nunitoRegular.copyWith(
-                                      color: ColorManager.bgSideMenu,
+                                    style: nunitoBold.copyWith(
+                                      color: ColorManager.black,
                                       fontSize: 35,
                                     ),
                                   ),

--- a/lib/presentation/views/class_rooms/widgets/edit_class_room_widget.dart
+++ b/lib/presentation/views/class_rooms/widgets/edit_class_room_widget.dart
@@ -190,8 +190,17 @@ class EditClassRoomWidget extends StatelessWidget {
               ),
               Row(
                 children: [
-                  const Expanded(
-                    child: ElevatedBackButton(),
+                  Expanded(
+                    child:
+                        GetBuilder<ClassRoomController>(builder: (controller) {
+                      return ElevatedBackButton(
+                        onPressed: () {
+                          controller.count = 1;
+                          controller.numbers = 0;
+                          controller.classSeats.clear();
+                        },
+                      );
+                    }),
                   ),
                   const SizedBox(
                     width: 20,
@@ -214,7 +223,6 @@ class EditClassRoomWidget extends StatelessWidget {
                                     .then(
                                     (value) {
                                       controller.count = 1;
-
                                       value
                                           ? {
                                               Get.back(),


### PR DESCRIPTION
This commit refactors the ElevatedBackButton widget to accept an onPressed callback and uses it in the EditClassRoomWidget to reset the class room controller when the back button is pressed. The controller's count, numbers, and classSeats properties are reset to their initial values.