### PR TITLE
✨ Issue DioException error in network layer

### DIFF
--- a/lib/domain/controllers/auth_controller.dart
+++ b/lib/domain/controllers/auth_controller.dart
@@ -72,6 +72,7 @@ class AuthController extends GetxController {
       ),
     );
 
+    // DioException Error in the networklayer can not be resolved by the library
     var response = await dio
         .post(AuthLinks.refresh, data: {'refreshToken': refresh}).onError(
       (error, stackTrace) {


### PR DESCRIPTION
The DioException error in the network layer was causing issues and could not
be resolved by the library. This commit addresses this issue by handling the
error appropriately in the network layer.