### PR TITLE
✨ Add empty state widget to SubjectSettingScreen

### DIFF
--- a/lib/presentation/views/subject_setting/subject_setting_screen.dart
+++ b/lib/presentation/views/subject_setting/subject_setting_screen.dart
@@ -88,6 +88,15 @@ class SubjectSettingScreen extends GetView<SubjectsController> {
                             )
                           : SearchableList<SubjectResModel>(
                               initialList: controller.subjects,
+                              emptyWidget: Center(
+                                child: Text(
+                                  "No data found",
+                                  style: nunitoBold.copyWith(
+                                    color: ColorManager.bgSideMenu,
+                                    fontSize: 16,
+                                  ),
+                                ),
+                              ),
                               filter: (value) => controller.subjects
                                   .where((element) => element.name!
                                       .toLowerCase()


### PR DESCRIPTION
Add a centered Text widget with a message of "No data found" when the list
is empty in the SubjectSettingScreen to provide a better user experience.