### PR TITLE
✨ feat: Enhance Proctor Screen UI

### DIFF
--- a/lib/presentation/views/proctor/proctor_screen.dart
+++ b/lib/presentation/views/proctor/proctor_screen.dart
@@ -408,18 +408,54 @@ class ProctorScreen extends GetView<ProctorController> {
                                                   .getLoadingIndicator(),
                                             )
                                           : controller.examRooms.isEmpty
-                                              ? Center(
-                                                  child: Text(
-                                                    controller.selectedEducationYearId ==
-                                                            null
-                                                        ? 'Please Select Education Year First'
-                                                        : controller.selectedControlMissionsId ==
-                                                                null
-                                                            ? 'Please Select Control Mission First'
-                                                            : 'No exam rooms added yet',
-                                                    style: nunitoBold,
-                                                  ),
-                                                )
+                                              ? controller.selectedEducationYearId !=
+                                                          null &&
+                                                      controller
+                                                              .selectedControlMissionsId !=
+                                                          null
+                                                  ? Center(
+                                                      child: Text(
+                                                        'No Exam Rooms Available. Please Create At Least One Exam Room',
+                                                        style:
+                                                            nunitoBold.copyWith(
+                                                          fontSize: 18,
+                                                        ),
+                                                      ),
+                                                    )
+                                                  : Column(
+                                                      mainAxisAlignment:
+                                                          MainAxisAlignment
+                                                              .center,
+                                                      children: [
+                                                        Text(
+                                                          'First Select Education Year',
+                                                          style: nunitoBold
+                                                              .copyWith(
+                                                            decoration: controller
+                                                                        .selectedEducationYearId !=
+                                                                    null
+                                                                ? TextDecoration
+                                                                    .lineThrough
+                                                                : null,
+                                                          ),
+                                                        ),
+                                                        const SizedBox(
+                                                          height: 20,
+                                                        ),
+                                                        Text(
+                                                          'Second Select Control Mission',
+                                                          style: nunitoBold
+                                                              .copyWith(
+                                                            decoration: controller
+                                                                        .selectedControlMissionsId !=
+                                                                    null
+                                                                ? TextDecoration
+                                                                    .lineThrough
+                                                                : null,
+                                                          ),
+                                                        ),
+                                                      ],
+                                                    )
                                               : GridView.builder(
                                                   shrinkWrap: true,
                                                   gridDelegate:


### PR DESCRIPTION
Improve the UI of the Proctor Screen by providing more informative
messages when there are no exam rooms available. The changes include:

- Display a clear message when the user has selected an Education Year
  and a Control Mission, but there are no exam rooms available.
- Provide step-by-step instructions when the user has not selected an
  Education Year or a Control Mission, with the selected items being
  highlighted with a strikethrough.
- This enhances the user experience by guiding the user through the
  necessary steps to view the exam rooms.