### PR TITLE
✨ feat(distribute-students): Add ability to block/unblock class desks

### DIFF
--- a/lib/domain/controllers/control_mission/distribute_students_controller.dart
+++ b/lib/domain/controllers/control_mission/distribute_students_controller.dart
@@ -34,6 +34,7 @@ class DistributeStudentsController extends GetxController {
   int availableStudentsCount = 0;
   Map<int?, List<ClassDeskResModel>> classDeskCollection = {};
   List<ClassDeskResModel> classDesks = [];
+  List<int> blockedClassDesks = [];
   Map<String, int> countByGrade = {};
   ExamRoomResModel examRoomResModel = ExamRoomResModel();
   List<GradeResModel> grades = [];
@@ -61,6 +62,16 @@ class DistributeStudentsController extends GetxController {
       }),
     ]);
     isLoading = false;
+    update();
+  }
+
+  void blockClassDesk({required int classDeskId}) {
+    blockedClassDesks.add(classDeskId);
+    update();
+  }
+
+  void unBlockClassDesk({required int classDeskId}) {
+    blockedClassDesks.remove(classDeskId);
     update();
   }
 


### PR DESCRIPTION
Adds the ability to block and unblock class desks in the
DistributeStudentsController. This allows the user to mark certain
class desks as unavailable, which can be useful in various scenarios,
such as when a desk is broken or needs to be reserved for a
specific purpose.

The changes include:

- Adding a new `blockedClassDesks` list to track the IDs of blocked
  class desks
- Implementing `blockClassDesk()` and `unBlockClassDesk()` methods to
  add or remove class desks from the blocked list
- Updating the `update()` method to trigger a UI refresh when the
  blocked class desks list is modified