### PR TITLE
🚀 feat(distribute_students_controller): Exclude blocked and

### DIFF
--- a/lib/domain/controllers/control_mission/distribute_students_controller.dart
+++ b/lib/domain/controllers/control_mission/distribute_students_controller.dart
@@ -512,6 +512,8 @@ class DistributeStudentsController extends GetxController {
       if (availableStudents[i].classDeskID == null) {
         availableStudents[i].classDeskID = availableStudents[i].classDeskID =
             classDesks
+                .whereNot(
+                    (classDesk) => blockedClassDesks.contains(classDesk.id))
                 .whereNot((classDesk) => availableStudents
                     .map((student) => student.classDeskID)
                     .contains(classDesk.id))


### PR DESCRIPTION
assigned class desks

Excludes blocked class desks and assigned class desks from the list of
available class desks during student distribution. This ensures that
students are only assigned to unblocked and unassigned class desks,
improving the overall distribution process.