### PR TITLE
👷‍♀️ feat(distribution_controller): update controller state after fetching exam rooms

### DIFF
--- a/lib/domain/controllers/control_mission/distribution_controller.dart
+++ b/lib/domain/controllers/control_mission/distribution_controller.dart
@@ -86,6 +86,7 @@ class DistributionController extends GetxController {
       },
     );
     isLodingGetExamRooms = false;
+    update();
   }
 
   Future<bool> getClassesRoomsBySchoolId() async {


### PR DESCRIPTION
Updates the controller state after fetching the exam rooms to ensure the UI
is properly updated. This is necessary to trigger a UI refresh and reflect
the latest data in the user interface.