### PR TITLE
✨ feat(dio_factory): Remove unused `pretty_dio_logger` package

### DIFF
--- a/lib/Data/Network/tools/dio_factory.dart
+++ b/lib/Data/Network/tools/dio_factory.dart
@@ -4,7 +4,7 @@ import 'package:control_system/app/configurations/app_links.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
-import 'package:pretty_dio_logger/pretty_dio_logger.dart';
+// import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 import '../../../domain/services/token_service.dart';
 import '../../Models/token/token_model.dart';

--- a/lib/presentation/views/batch_documents/widgets/cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/cover_widget.dart
@@ -8,6 +8,7 @@ import 'package:intl/intl.dart';
 
 import '../../../resource_manager/styles_manager.dart';
 
+// ignore: must_be_immutable
 class CoverWidget extends StatelessWidget {
   ExamMissionResModel examMissionObject;
   ControlMissionResModel controlMissionObject;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -58,7 +58,7 @@ packages:
     source: hosted
     version: "3.2.1"
   badges:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: badges
       sha256: a7b6bbd60dce418df0db3058b53f9d083c22cdb5132a052145dc267494df0b84

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   file_saver : ^0.2.13 
   url_launcher: ^6.3.0
   loading_indicator: ^3.1.1
+  badges: ^3.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Removes the `pretty_dio_logger` package from the `dio_factory.dart` file,
as it is no longer being used in the project.

♻️ refactor(cover_widget): Ignore `must_be_immutable` lint rule

Adds the `// ignore: must_be_immutable` comment to the `CoverWidget` class,
as the lint rule is not applicable in this case.

🔧 feat(pubspec): Add `badges` package

Adds the `badges` package to the project's dependencies in the `pubspec.yaml`
file, as it is likely required for a new feature or functionality.