### PR TITLE
🚑 fix(response_handler): handle null data in response

### DIFF
--- a/lib/Data/Network/response_handler.dart
+++ b/lib/Data/Network/response_handler.dart
@@ -146,10 +146,19 @@ class ResponseHandler<T> {
 
     if (response.statusCode == 200 || response.statusCode == 201) {
       if (response.data['status'] == true) {
-        try {
-          return Right(converter(response.data['data']));
-        } catch (e) {
-          return Left(Failure(2025, 'error while convert $T from json'));
+        if (response.data['data'] != null) {
+          try {
+            return Right(converter(response.data['data']));
+          } catch (e) {
+            return Left(Failure(2025, 'error while convert $T from json'));
+          }
+        } else {
+          return Left(
+            Failure(
+              2025,
+              'No data found',
+            ),
+          );
         }
       } else {
         return Left(


### PR DESCRIPTION
The changes made in this commit address a potential issue where the
response data may be `null`. Previously, the code would attempt to
convert the `null` data, which would result in an error. The new
changes check if the `data` field in the response is not `null`
before attempting the conversion. If the `data` field is `null`, a
`Failure` object with a specific error code and message is returned
instead.

This change ensures that the `ResponseHandler` class can gracefully
handle responses with missing or `null` data, providing a more
robust error handling mechanism.