### PR TITLE
✨ feat(my_text_form_field): add maxLength property

### DIFF
--- a/lib/presentation/resource_manager/ReusableWidget/my_text_form_field.dart
+++ b/lib/presentation/resource_manager/ReusableWidget/my_text_form_field.dart
@@ -10,6 +10,7 @@ class MytextFormFiled extends StatelessWidget {
     this.title,
     required this.controller,
     this.maxlines = 1,
+    this.maxLength,
     this.isEnable,
     this.myValidation,
     this.isNumber,
@@ -31,6 +32,7 @@ class MytextFormFiled extends StatelessWidget {
   final bool? isEnable;
   final bool? isNumber;
   final int maxlines;
+  final int? maxLength;
   final bool obscureText;
   final Widget? suffixIcon;
   final List<TextInputFormatter>? textInputs;
@@ -70,6 +72,7 @@ class MytextFormFiled extends StatelessWidget {
       ),
       controller: controller,
       maxLines: maxlines,
+      maxLength: maxLength,
       enabled: isEnable,
       validator: myValidation,
       onChanged: onChange,


### PR DESCRIPTION
Adds a new `maxLength` parameter to the `MytextFormFiled` widget, allowing
the maximum length of the input text to be specified. This is useful for
limiting the amount of text a user can enter in a form field.