### PR TITLE
🎨 feat(SetDegrees): Update header and add student degree display

### DIFF
--- a/lib/presentation/views/set_degrees/set_degrees_screen.dart
+++ b/lib/presentation/views/set_degrees/set_degrees_screen.dart
@@ -25,7 +25,7 @@ class SetDegreesScreen extends GetView<BarcodeController> {
             color: ColorManager.bgColor,
             child: Column(
               children: [
-                const HeaderWidget(text: "Student Grades"),
+                const HeaderWidget(text: "Student Degrees"),
                 const SizedBox(
                   height: 20,
                 ),
@@ -116,6 +116,41 @@ class SetDegreesScreen extends GetView<BarcodeController> {
                                                           .bgSideMenu,
                                                     ),
                                                   ),
+                                                  const SizedBox(
+                                                    width: 20,
+                                                  ),
+                                                  controller.barcodeResModel
+                                                                  ?.studentDegree !=
+                                                              null &&
+                                                          controller
+                                                              .barcodeResModel!
+                                                              .studentDegree!
+                                                              .isNotEmpty
+                                                      ? Row(
+                                                          children: [
+                                                            Text(
+                                                              'Degree : ',
+                                                              style:
+                                                                  nunitoRegular,
+                                                            ),
+                                                            Text(
+                                                              "${controller.barcodeResModel?.studentDegree}",
+                                                              style:
+                                                                  nunitoRegular
+                                                                      .copyWith(
+                                                                color: int.parse(controller
+                                                                            .barcodeResModel!
+                                                                            .studentDegree!) <
+                                                                        60
+                                                                    ? ColorManager
+                                                                        .red
+                                                                    : ColorManager
+                                                                        .green,
+                                                              ),
+                                                            ),
+                                                          ],
+                                                        )
+                                                      : const SizedBox.shrink(),
                                                 ],
                                               ),
                                               const SizedBox(


### PR DESCRIPTION
This commit updates the header text from "Student Grades" to "Student Degrees" to better reflect the purpose of the screen. Additionally, it adds a new section to display the student's degree if it is present in the barcode response model. The degree is displayed with a green color if it is 60 or above, and red if it is below 60.