### PR TITLE
🔧 feat: Add `focusNode` parameter to `MytextFormFiled` widget

### DIFF
--- a/lib/presentation/resource_manager/ReusableWidget/my_text_form_field.dart
+++ b/lib/presentation/resource_manager/ReusableWidget/my_text_form_field.dart
@@ -21,6 +21,7 @@ class MytextFormFiled extends StatelessWidget {
     this.enableBorderColor = ColorManager.grey,
     this.foucsBorderColor = ColorManager.primary,
     this.onFieldSubmitted,
+    this.focusNode,
   });
 
   final String? Function(String? newValue)? myValidation;
@@ -37,6 +38,7 @@ class MytextFormFiled extends StatelessWidget {
   final Widget? suffixIcon;
   final List<TextInputFormatter>? textInputs;
   final String? title;
+  final FocusNode? focusNode;
 
   @override
   Widget build(BuildContext context) {
@@ -78,6 +80,7 @@ class MytextFormFiled extends StatelessWidget {
       onChanged: onChange,
       onFieldSubmitted: onFieldSubmitted,
       obscureText: obscureText,
+      focusNode: focusNode,
     ).paddingOnly(
       top: AppPading.p25,
     );


### PR DESCRIPTION
The changes include adding a new `focusNode` parameter to the `MytextFormFiled`
widget. This allows the parent component to control the focus state of the
text form field, which can be useful for things like automatically focusing
the field when the widget is rendered or moving focus to another field when
the current one is submitted.