### PR TITLE
🚀 feat(proctor_screen): Enhance education year selection message

### DIFF
--- a/lib/presentation/views/proctor/proctor_screen.dart
+++ b/lib/presentation/views/proctor/proctor_screen.dart
@@ -77,7 +77,7 @@ class ProctorScreen extends GetView<ProctorController> {
                             : controller.selectedEducationYearId == null
                                 ? Center(
                                     child: Text(
-                                      "Please Select Education Year First",
+                                      "Please Select Education Year To View Control Missions",
                                       style: nunitoRegular,
                                     ),
                                   )


### PR DESCRIPTION
The changes made in this commit improve the user experience by providing a more
 informative message when the user has not selected an education year. The
 updated message now clearly instructs the user to select an education year in
 order to view the control missions.