### PR TITLE
✨ feat(proctor_controller): handle education year change

### DIFF
--- a/lib/domain/controllers/proctor_controller.dart
+++ b/lib/domain/controllers/proctor_controller.dart
@@ -230,7 +230,11 @@ class ProctorController extends GetxController {
   void onEducationYearChange(List<ValueItem<dynamic>> selectedOptions) {
     selectedEducationYearId = selectedOptions.firstOrNull?.value;
     selectedEducationYearId != null
-        ? getControlMissionByEducationYearId()
+        ? {
+            getControlMissionByEducationYearId(),
+            selectedControlMissionsId = null,
+            examRooms = [],
+          }
         : {
             selectedControlMissionsId = null,
             examRooms = [],


### PR DESCRIPTION
When the education year is changed, reset the selected control mission
and exam rooms to ensure a consistent state. This change ensures that
the UI reflects the updated selection and provides a better user
experience.