### PR TITLE
🔨 refactor(AppConstants): replace mutable durations with const

### DIFF
--- a/lib/presentation/resource_manager/constants/app_constatnts.dart
+++ b/lib/presentation/resource_manager/constants/app_constatnts.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/material.dart';
+
 abstract class AppConstants {
-  static Duration durationFourSeconds = const Duration(seconds: 4);
-  static Duration durationOneSecond = const Duration(seconds: 1);
-  static Duration durationThreeSeconds = const Duration(seconds: 3);
-  static Duration durationTwoSeconds = const Duration(seconds: 2);
+  static const Duration durationFourSeconds = Duration(seconds: 4);
+  static const Duration durationOneSecond = Duration(seconds: 1);
+  static const Duration durationThreeSeconds = Duration(seconds: 3);
+  static const Duration durationTwoSeconds = Duration(seconds: 2);
+  static const Duration mediumDuration = Durations.medium1;
 }


### PR DESCRIPTION
Refactors the `AppConstants` class to use `const` durations instead of
mutable `Duration` objects. This improves the overall efficiency and
maintainability of the application by ensuring that these values are
immutable and can be more easily optimized by the compiler.