### PR TITLE
🚀 feat(ControlMission): Add start and end date display

### DIFF
--- a/lib/presentation/views/batch_documents/widgets/cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/cover_widget.dart
@@ -1,5 +1,5 @@
 import 'package:awesome_dialog/awesome_dialog.dart';
-import 'package:control_system/Data/Models/control_mission/control_mission_model.dart';
+import 'package:control_system/Data/Models/control_mission/control_mission_res_model.dart';
 import 'package:control_system/Data/Models/exam_mission/exam_mission_res_model.dart';
 import 'package:control_system/domain/controllers/batch_documents.dart/cover_sheets_controller.dart';
 import 'package:control_system/presentation/resource_manager/ReusableWidget/my_snak_bar.dart';

--- a/lib/presentation/views/control_mission/widgets/control_mission_review_widget.dart
+++ b/lib/presentation/views/control_mission/widgets/control_mission_review_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 
 import '../../../../Data/Models/control_mission/control_mission_res_model.dart';
 import '../../../../domain/controllers/controllers.dart';
@@ -46,10 +47,33 @@ class ControlMissionReviewWidget extends GetView<ControlMissionController> {
                       style: nunitoBold.copyWith(
                           color: ColorManager.bgSideMenu, fontSize: 30),
                     ),
+                    const SizedBox(
+                      height: 10,
+                    ),
                     Text(
                       "Number Of Students: ${controlMission.count?['student_seat_numnbers']}",
                       style: nunitoRegular.copyWith(
                           color: ColorManager.bgSideMenu, fontSize: 16),
+                    ),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    Row(
+                      children: [
+                        Text(
+                          "Start Date: ${DateFormat("dd-MM-yyyy").format(DateTime.parse(controlMission.startDate!.substring(0, controlMission.startDate!.length - 1).toString()))}",
+                          style: nunitoRegular.copyWith(
+                              color: ColorManager.green, fontSize: 16),
+                        ),
+                        const SizedBox(
+                          width: 10,
+                        ),
+                        Text(
+                          "End Date: ${DateFormat("dd-MM-yyyy").format(DateTime.parse(controlMission.endDate!.substring(0, controlMission.endDate!.length - 1).toString()))}",
+                          style: nunitoRegular.copyWith(
+                              color: ColorManager.red, fontSize: 16),
+                        ),
+                      ],
                     ),
                   ],
                 ),


### PR DESCRIPTION
This commit adds the display of the control mission start and end dates to the `ControlMissionReviewWidget`. The dates are formatted using the `intl` package and displayed in a row.

The changes were made to provide users with more information about the control mission they are reviewing, making it easier to understand the timeline of the mission.