### PR TITLE
✨ feat(Exam Mission): Update period field to boolean

### DIFF
--- a/lib/Data/Models/exam_mission/exam_mission_res_model.dart
+++ b/lib/Data/Models/exam_mission/exam_mission_res_model.dart
@@ -69,7 +69,7 @@ class ExamMissionResModel {
   String? month;
   String? pdf;
   String? pdfV2;
-  int? period;
+  bool? period;
   String? startTime;
   int? subjectsID;
   String? updatedAt;


### PR DESCRIPTION
Updates the `period` field in the `ExamMissionResModel` to be a boolean
instead of an integer. This change aligns with the expected data type
for this field and simplifies the model.