### PR TITLE
🔒 feat(ExamMissionResModel): Add `createOnly` property

### DIFF
--- a/lib/Data/Models/exam_mission/exam_mission_res_model.dart
+++ b/lib/Data/Models/exam_mission/exam_mission_res_model.dart
@@ -39,6 +39,7 @@ class ExamMissionResModel {
     year = json['Year'];
     finalDegree = json['FinalDegree'];
     period = json['Period'];
+    createOnly = json['Create_Only'];
     duration = json['duration'];
     startTime = json['start_time'];
     endTime = json['end_time'];
@@ -70,6 +71,7 @@ class ExamMissionResModel {
   String? pdf;
   String? pdfV2;
   bool? period;
+  bool? createOnly;
   String? startTime;
   int? subjectsID;
   String? updatedAt;


### PR DESCRIPTION
Adds a new `createOnly` property to the `ExamMissionResModel` class to
represent whether the exam mission is created only or not. This
information is necessary for the application to handle the exam mission
creation and update scenarios differently.