### PR TITLE
🎨 feat(assign_proctor_to_exam_by_room_id): Enhance exam period filtering

### DIFF
--- a/lib/presentation/views/proctor/widgets/assign_proctor_to_exam_by_room_id.dart
+++ b/lib/presentation/views/proctor/widgets/assign_proctor_to_exam_by_room_id.dart
@@ -77,19 +77,23 @@ class AssignProctorToExamMission extends GetView<ProctorController> {
                     ),
                   ),
                   const Spacer(),
-                  ElevatedButton(
-                    onPressed: () async {
-                      controller.assignProctorToExamRoom();
-                    },
-                    child: const Text('assign to proctor'),
-                  ),
+                  if (controller.selectedExamRoom!.controlMissionResModel!
+                      .examMissionsResModel!.data!
+                      .where((exam) => !exam.period!)
+                      .isNotEmpty)
+                    ElevatedButton(
+                      onPressed: () async {
+                        controller.assignProctorToExamRoom();
+                      },
+                      child: const Text('assign to proctor'),
+                    ),
                 ],
               ),
               ListBody(
                 mainAxis: Axis.vertical,
                 children: controller.selectedExamRoom!.controlMissionResModel!
                     .examMissionsResModel!.data!
-                    .where((exam) => exam.period == 0)
+                    .where((exam) => exam.period!)
                     .map(
                       (exam) => Padding(
                         padding: const EdgeInsets.all(8.0),
@@ -188,7 +192,7 @@ class AssignProctorToExamMission extends GetView<ProctorController> {
                   const Spacer(),
                   if (controller.selectedExamRoom!.controlMissionResModel!
                       .examMissionsResModel!.data!
-                      .where((exam) => exam.period == 1)
+                      .where((exam) => !exam.period!)
                       .isNotEmpty)
                     ElevatedButton(
                       onPressed: () async {
@@ -229,7 +233,7 @@ class AssignProctorToExamMission extends GetView<ProctorController> {
                 mainAxis: Axis.vertical,
                 children: controller.selectedExamRoom!.controlMissionResModel!
                     .examMissionsResModel!.data!
-                    .where((exam) => exam.period == 1)
+                    .where((exam) => !exam.period!)
                     .map(
                       (exam) => Padding(
                         padding: const EdgeInsets.all(8.0),


### PR DESCRIPTION
The changes in this commit focus on improving the filtering of exam missions based on the exam period. Specifically:

- The `where` clause in the `ListBody` widgets has been updated to filter exams where `exam.period` is not null, instead of checking for a specific period value.
- The `ElevatedButton` for assigning a proctor is now conditionally rendered, based on whether there are any exams with a period that is not null.

These changes ensure a more accurate and flexible handling of the exam period attribute, allowing for a better user experience when assigning proctors to exams.