### PR TITLE
✨ refactor(cover_widget): update exam date display logic

### DIFF
--- a/lib/presentation/views/batch_documents/widgets/cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/cover_widget.dart
@@ -110,7 +110,7 @@ class CoverWidget extends GetView<CoversSheetsController> {
                     mainAxisAlignment: MainAxisAlignment.start,
                     children: [
                       Text(
-                        "Exam Date : ${examMissionObject.startTime != null ? DateFormat('yyyy,MM,dd (HH:mm)').format(DateTime.parse(examMissionObject.startTime!)) : examMissionObject.month}  ( ${examMissionObject.period == 0 ? 'Session One Exams' : 'Session Two Exams'} )",
+                        "Exam Date : ${examMissionObject.startTime != null ? DateFormat('yyyy,MM,dd (HH:mm)').format(DateTime.parse(examMissionObject.startTime!)) : examMissionObject.month}  ( ${examMissionObject.period! ? 'Session One Exams' : 'Session Two Exams'} )",
                         style: nunitoRegularStyle().copyWith(
                           color: ColorManager.primary,
                         ),


### PR DESCRIPTION
The changes in this commit update the logic for displaying the exam date and
session information in the `CoverWidget`. The previous implementation had a
conditional check for the `period` property that was incorrect, leading to
inaccurate session display. The updated code correctly checks the `period`
property and displays the appropriate session information.