### PR TITLE
✨ feat: Modify filter logic for exam missions

### DIFF
--- a/lib/presentation/views/proctor/widgets/assign_proctor_to_exam_by_room_id.dart
+++ b/lib/presentation/views/proctor/widgets/assign_proctor_to_exam_by_room_id.dart
@@ -79,7 +79,7 @@ class AssignProctorToExamMission extends GetView<ProctorController> {
                   const Spacer(),
                   if (controller.selectedExamRoom!.controlMissionResModel!
                       .examMissionsResModel!.data!
-                      .where((exam) => !exam.period!)
+                      .where((exam) => exam.period!)
                       .isNotEmpty)
                     ElevatedButton(
                       onPressed: () async {


### PR DESCRIPTION
Modifies the filter logic in the `AssignProctorToExamMission` widget
to display only exam missions with a non-null `period` value. This
change ensures that the user can only assign proctors to exam missions
that have a valid period set.