### PR TITLE
feat(🎨): Reset selected date and clear date input field

### DIFF
--- a/lib/domain/controllers/proctor_controller.dart
+++ b/lib/domain/controllers/proctor_controller.dart
@@ -409,6 +409,8 @@ class ProctorController extends GetxController {
     selectedControlMissionsId = selectedOptions.firstOrNull?.value;
     selectedExamRoom = null;
     selectedProctor = null;
+    selectedDate = null;
+    dateController.text = '';
     examRooms = [];
     update(['proctorEntryScreen']);
   }


### PR DESCRIPTION
Resets the selected date to null and clears the date input field
in the Proctor Controller. This is done to ensure a consistent
user experience when navigating between different screens or
options within the application.