### PR TITLE
🔥 feat(EditCoverSheetController): Remove unnecessary onClose method

### DIFF
--- a/lib/domain/controllers/batch_documents.dart/edit_cover_controller.dart
+++ b/lib/domain/controllers/batch_documents.dart/edit_cover_controller.dart
@@ -200,9 +200,4 @@ class EditCoverSheetController extends GetxController {
     update();
     return updateExamMission;
   }
-
-  @override
-  void onClose() {
-    super.onClose();
-  }
 }


### PR DESCRIPTION
Removes the unused `onClose` method from the `EditCoverSheetController`
class. This method was not providing any functional value and was
cluttering the codebase.