### PR TITLE
✨ feat(datetime): Add method to get month name from DateTime

### DIFF
--- a/lib/app/extensions/date_time_extension.dart
+++ b/lib/app/extensions/date_time_extension.dart
@@ -1,0 +1,7 @@
+import 'package:intl/intl.dart';
+
+extension DateTimeExtension on DateTime {
+  String get toMonthName {
+    return DateFormat.MMMM().format(this);
+  }
+}


### PR DESCRIPTION
Adds a new method `toMonthName` to the `DateTimeExtension` class that
returns the month name of the `DateTime` instance using the
`DateFormat.MMMM()` formatter from the `intl` package.