### PR TITLE
✨ feat: Add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# IDE - VSCode
+.vscode/*


### PR DESCRIPTION
Adds the .vscode directory to the .gitignore file to exclude
the Visual Studio Code configuration files from the repository.
This ensures that the project remains portable and avoids
conflicts between different development environments.