### PR TITLE
♻️ refactor(roles_screen): improve layout and readability

### DIFF
--- a/lib/presentation/views/roles/roles_screen.dart
+++ b/lib/presentation/views/roles/roles_screen.dart
@@ -163,22 +163,104 @@ class RolesScreen extends GetView<RolesController> {
                                                                 .roles[index]
                                                                 .screens!
                                                                 .isNotEmpty
-                                                        ? controller
-                                                            .roles[index]
-                                                            .screens!
-                                                            .map(
-                                                              (screen) => Text(
-                                                                screen.name,
-                                                                style: nunitoBold
-                                                                    .copyWith(
+                                                        ? [
+                                                            Column(
+                                                              children: [
+                                                                const Divider(
                                                                   color:
                                                                       ColorManager
                                                                           .black,
-                                                                  fontSize: 18,
                                                                 ),
+                                                                Row(
+                                                                  children: [
+                                                                    FittedBox(
+                                                                      child:
+                                                                          Text(
+                                                                        "Front Id",
+                                                                        style: nunitoBold
+                                                                            .copyWith(
+                                                                          color:
+                                                                              ColorManager.black,
+                                                                          fontSize:
+                                                                              20,
+                                                                        ),
+                                                                      ),
+                                                                    ),
+                                                                    const Spacer(),
+                                                                    FittedBox(
+                                                                      child:
+                                                                          Text(
+                                                                        "Screens",
+                                                                        style: nunitoBold
+                                                                            .copyWith(
+                                                                          color:
+                                                                              ColorManager.black,
+                                                                          fontSize:
+                                                                              20,
+                                                                        ),
+                                                                      ),
+                                                                    ),
+                                                                  ],
+                                                                ).paddingSymmetric(
+                                                                  horizontal:
+                                                                      10,
+                                                                ),
+                                                              ],
+                                                            ),
+                                                            ...controller
+                                                                .roles[index]
+                                                                .screens!
+                                                                .map(
+                                                              (screen) =>
+                                                                  Column(
+                                                                children: [
+                                                                  const Divider(
+                                                                    color: ColorManager
+                                                                        .black,
+                                                                  ),
+                                                                  Row(
+                                                                    children: [
+                                                                      FittedBox(
+                                                                        child:
+                                                                            Text(
+                                                                          screen
+                                                                              .frontId,
+                                                                          style:
+                                                                              nunitoBold.copyWith(
+                                                                            color:
+                                                                                ColorManager.black,
+                                                                            fontSize:
+                                                                                18,
+                                                                          ),
+                                                                        ),
+                                                                      ),
+                                                                      const Spacer(),
+                                                                      FittedBox(
+                                                                        child:
+                                                                            Text(
+                                                                          screen
+                                                                              .name,
+                                                                          style:
+                                                                              nunitoBold.copyWith(
+                                                                            color:
+                                                                                ColorManager.black,
+                                                                            fontSize:
+                                                                                18,
+                                                                          ),
+                                                                        ),
+                                                                      ),
+                                                                    ],
+                                                                  ).paddingSymmetric(
+                                                                    horizontal:
+                                                                        10,
+                                                                  ),
+                                                                ],
                                                               ),
-                                                            )
-                                                            .toList()
+                                                            ),
+                                                            const SizedBox(
+                                                              height: 15,
+                                                            ),
+                                                          ]
                                                         : [
                                                             const SizedBox(
                                                               height: 10,


### PR DESCRIPTION
The changes in this commit aim to improve the layout and readability of the
`RolesScreen` widget. The main updates are:

- Add a divider and a header row with "Front Id" and "Screens" column labels
  to provide a clearer structure for the screen information.
- Wrap the screen names in a `FittedBox` to ensure they are properly sized and
  not truncated.
- Use a `Column` to vertically stack the header row and the screen name rows,
  creating a more organized and visually appealing layout.

These changes enhance the overall user experience and make the screen
information easier to scan and understand.