### PR TITLE
🔖 feat(date-conversion): Improve date string conversion to ISO8601

### DIFF
--- a/lib/app/extensions/convert_date_string_to_iso8601_string_extension.dart
+++ b/lib/app/extensions/convert_date_string_to_iso8601_string_extension.dart
@@ -1,6 +1,6 @@
 extension ConvertDateStringToIso8601StringExtension on String {
   String convertDateStringToIso8601String() {
-    final date = DateTime.parse(this);
-    return '${date.toIso8601String()}Z';
+    final date = DateTime.parse(this).toUtc();
+    return date.toIso8601String();
   }
 }


### PR DESCRIPTION
The changes made in this commit improve the date string conversion to ISO8601
format. The `convertDateStringToIso8601String()` extension method now converts
the parsed date to UTC before formatting it in the ISO8601 string. This ensures
that the resulting date string is always in the correct format, regardless of
the original timezone of the input date.