### PR TITLE
✨ feat(datetime): Convert datetime to local timezone

### DIFF
--- a/lib/presentation/views/admin_screen/widgets/admin_widget.dart
+++ b/lib/presentation/views/admin_screen/widgets/admin_widget.dart
@@ -114,7 +114,7 @@ class AdminWidget extends GetView<AdminController> {
                                           children: [
                                             Flexible(
                                               child: Text(
-                                                "Created At: ${DateFormat("dd-MM-yyyy HH:mm").format(DateTime.parse(item.createdAt!))}",
+                                                "Created At: ${DateFormat("dd-MM-yyyy HH:mm").format(DateTime.parse(item.createdAt!).toLocal())}",
                                                 style: nunitoRegular.copyWith(
                                                   color: ColorManager.bgSideMenu
                                                       .withOpacity(0.7),

--- a/lib/presentation/views/admin_screen/widgets/all_user_widget.dart
+++ b/lib/presentation/views/admin_screen/widgets/all_user_widget.dart
@@ -143,7 +143,7 @@ class AllUserWidget extends GetView<AdminController> {
                                                 children: [
                                                   Flexible(
                                                     child: Text(
-                                                      "Created At: ${DateFormat("dd-MM-yyyy HH:mm").format(DateTime.parse(item.createdAt!))}",
+                                                      "Created At: ${DateFormat("dd-MM-yyyy HH:mm").format(DateTime.parse(item.createdAt!).toLocal())}",
                                                       style: nunitoRegular
                                                           .copyWith(
                                                               color: ColorManager

--- a/lib/presentation/views/admin_screen/widgets/user_in_school_widget.dart
+++ b/lib/presentation/views/admin_screen/widgets/user_in_school_widget.dart
@@ -147,7 +147,7 @@ class UserInSchoolWidget extends GetView<AdminController> {
                                                 children: [
                                                   Flexible(
                                                     child: Text(
-                                                      "Created At: ${DateFormat("dd-MM-yyyy HH:mm").format(DateTime.parse(item.createdAt!))}",
+                                                      "Created At: ${DateFormat("dd-MM-yyyy HH:mm").format(DateTime.parse(item.createdAt!).toLocal())}",
                                                       style: nunitoRegular
                                                           .copyWith(
                                                         color: ColorManager

--- a/lib/presentation/views/batch_documents/widgets/add_new_cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/add_new_cover_widget.dart
@@ -353,8 +353,8 @@ class AddNewCoverWidget extends GetView<CreateCoversSheetsController> {
 
                     DateTime? selectedDate = await selectDate(context);
                     if (selectedDate != null) {
-                      dateController.text =
-                          DateFormat('dd MMMM yyyy').format(selectedDate);
+                      dateController.text = DateFormat('dd MMMM yyyy')
+                          .format(selectedDate.toLocal());
                     } else {
                       dateController.text = 'dd MMMM yyyy';
                     }
@@ -534,15 +534,18 @@ class AddNewCoverWidget extends GetView<CreateCoversSheetsController> {
     final DateTime? picked = await showDatePicker(
       context: context,
       initialDate: DateTime.parse(controller.controlMissionResModel!.startDate!
-          .substring(
-              0, controller.controlMissionResModel!.startDate!.length - 1)),
+              .substring(
+                  0, controller.controlMissionResModel!.startDate!.length - 1))
+          .toLocal(),
       initialDatePickerMode: DatePickerMode.day,
       firstDate: DateTime.parse(controller.controlMissionResModel!.startDate!
-          .substring(
-              0, controller.controlMissionResModel!.startDate!.length - 1)),
+              .substring(
+                  0, controller.controlMissionResModel!.startDate!.length - 1))
+          .toLocal(),
       lastDate: DateTime.parse(controller.controlMissionResModel!.endDate!
-          .substring(
-              0, controller.controlMissionResModel!.endDate!.length - 1)),
+              .substring(
+                  0, controller.controlMissionResModel!.endDate!.length - 1))
+          .toLocal(),
     );
 
     if (picked != null) {

--- a/lib/presentation/views/batch_documents/widgets/cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/cover_widget.dart
@@ -165,7 +165,7 @@ class CoverWidget extends GetView<CoversSheetsController> {
                     mainAxisAlignment: MainAxisAlignment.start,
                     children: [
                       Text(
-                        "Exam Date : ${examMissionObject.startTime != null ? DateFormat('yyyy,MM,dd (HH:mm)').format(DateTime.parse(examMissionObject.startTime!)) : "${examMissionObject.month} "}  ( ${examMissionObject.period! ? 'Session One Exams' : 'Session Two Exams'} )",
+                        "Exam Date : ${examMissionObject.startTime != null ? DateFormat('yyyy,MM,dd (HH:mm)').format(DateTime.parse(examMissionObject.startTime!).toLocal()) : "${examMissionObject.month} "}  ( ${examMissionObject.period! ? 'Session One Exams' : 'Session Two Exams'} )",
                         style: nunitoRegularStyle().copyWith(
                           color: ColorManager.primary,
                         ),

--- a/lib/presentation/views/batch_documents/widgets/edit_cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/edit_cover_widget.dart
@@ -21,7 +21,7 @@ class EditCoverWidget extends GetView<EditCoverSheetController> {
       text: examMissionObject.endTime == null
           ? null
           : DateFormat('yyyy-MM-dd HH:mm')
-              .format(DateTime.parse(examMissionObject.endTime!)));
+              .format(DateTime.parse(examMissionObject.endTime!).toLocal()));
   final TextEditingController examFinalDegreeController =
       TextEditingController();
 
@@ -31,7 +31,7 @@ class EditCoverWidget extends GetView<EditCoverSheetController> {
       text: examMissionObject.endTime == null
           ? "${examMissionObject.month} ${examMissionObject.year}"
           : DateFormat('yyyy-MM-dd HH:mm')
-              .format(DateTime.parse(examMissionObject.startTime!)));
+              .format(DateTime.parse(examMissionObject.startTime!).toLocal()));
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   EditCoverWidget(
@@ -363,9 +363,11 @@ class EditCoverWidget extends GetView<EditCoverSheetController> {
     }
 
     final DateTime startDate = DateTime.parse(controlMissionObject.startDate!
-        .substring(0, controlMissionObject.startDate!.length - 1));
+            .substring(0, controlMissionObject.startDate!.length - 1))
+        .toLocal();
     final DateTime endDate = DateTime.parse(controlMissionObject.endDate!
-        .substring(0, controlMissionObject.endDate!.length - 1));
+            .substring(0, controlMissionObject.endDate!.length - 1))
+        .toLocal();
 
     final DateTime? pickedDate = await showDatePicker(
       context: context,

--- a/lib/presentation/views/batch_documents/widgets/officer_edit_cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/officer_edit_cover_widget.dart
@@ -239,12 +239,15 @@ class OfficerEditCoverWidget extends GetView<EditCoverSheetController> {
     final DateTime? picked = await showDatePicker(
       context: context,
       initialDate: DateTime.parse(controlMissionObject.startDate!
-          .substring(0, controlMissionObject.startDate!.length - 1)),
+              .substring(0, controlMissionObject.startDate!.length - 1))
+          .toLocal(),
       initialDatePickerMode: DatePickerMode.day,
       firstDate: DateTime.parse(controlMissionObject.startDate!
-          .substring(0, controlMissionObject.startDate!.length - 1)),
+              .substring(0, controlMissionObject.startDate!.length - 1))
+          .toLocal(),
       lastDate: DateTime.parse(controlMissionObject.endDate!
-          .substring(0, controlMissionObject.endDate!.length - 1)),
+              .substring(0, controlMissionObject.endDate!.length - 1))
+          .toLocal(),
     );
 
     if (picked != null) {

--- a/lib/presentation/views/control_mission/widgets/control_mission_review_widget.dart
+++ b/lib/presentation/views/control_mission/widgets/control_mission_review_widget.dart
@@ -24,7 +24,7 @@ class ControlMissionReviewWidget extends GetView<ControlMissionController> {
             color: Colors.grey.withOpacity(0.5),
             spreadRadius: 5,
             blurRadius: 20,
-            offset: const Offset(2, 15), 
+            offset: const Offset(2, 15),
           ),
         ],
         color: ColorManager.ligthBlue,
@@ -69,7 +69,7 @@ class ControlMissionReviewWidget extends GetView<ControlMissionController> {
                             FittedBox(
                               fit: BoxFit.contain,
                               child: Text(
-                                "Start Date: ${DateFormat("dd-MM-yyyy").format(DateTime.parse(controlMission.startDate!.substring(0, controlMission.startDate!.length - 1).toString()))}",
+                                "Start Date: ${DateFormat("dd-MM-yyyy").format(DateTime.parse(controlMission.startDate!.substring(0, controlMission.startDate!.length - 1).toString()).toLocal())}",
                                 style: nunitoRegular.copyWith(
                                     color: ColorManager.green, fontSize: 16),
                               ),
@@ -78,7 +78,7 @@ class ControlMissionReviewWidget extends GetView<ControlMissionController> {
                             FittedBox(
                               fit: BoxFit.contain,
                               child: Text(
-                                "End Date: ${DateFormat("dd-MM-yyyy").format(DateTime.parse(controlMission.endDate!.substring(0, controlMission.endDate!.length - 1).toString()))}",
+                                "End Date: ${DateFormat("dd-MM-yyyy").format(DateTime.parse(controlMission.endDate!.substring(0, controlMission.endDate!.length - 1).toString()).toLocal())}",
                                 style: nunitoRegular.copyWith(
                                     color: ColorManager.red, fontSize: 16),
                               ),


### PR DESCRIPTION
This commit addresses an issue where the datetime displayed in the application was not being converted to the local timezone. The changes made ensure that the datetime values are converted to the local timezone before being displayed to the user.

The changes were made to the following files:

- `edit_cover_widget.dart`: The `endTime` field is now being converted to the local timezone before being displayed.
- `officer_edit_cover_widget.dart`: The `startDate` and `endDate` fields are now being converted to the local timezone before being displayed.
- `cover_widget.dart`: The `startTime` field is now being converted to the local timezone before being displayed.
- `user_in_school_widget.dart`: The `createdAt` field is now being converted to the local timezone before being displayed.
- `control_mission_review_widget.dart`: The `startDate` field is now being converted to the local timezone before being displayed.
- `admin_widget.dart`: The `createdAt` field is now being converted to the local timezone before being displayed.

These changes ensure that the datetime values displayed in the application accurately reflect the user's local timezone, improving the overall user experience.