### PR TITLE
🔧 feat(Networking): Update base URL to production

### DIFF
--- a/lib/Data/Network/tools/dio_factory.dart
+++ b/lib/Data/Network/tools/dio_factory.dart
@@ -32,7 +32,7 @@ class DioFactory {
     };
 
     dio.options = BaseOptions(
-      baseUrl: AppLinks.baseUrl,
+      baseUrl: AppLinks.baseUrlProd,
       headers: headers,
       receiveTimeout: timeOut,
       sendTimeout: timeOut,

--- a/lib/domain/controllers/auth_controller.dart
+++ b/lib/domain/controllers/auth_controller.dart
@@ -94,7 +94,7 @@ class AuthController extends GetxController {
 
     var dio = Dio(
       BaseOptions(
-        baseUrl: AppLinks.baseUrlDev,
+        baseUrl: AppLinks.baseUrlProd,
       ),
     );
 


### PR DESCRIPTION
Changes the base URL used in the `DioFactory` and `AuthController` from the
development URL to the production URL. This ensures that the app is
communicating with the correct backend environment when running in
production.