### PR TITLE
🚀 feat(control_mission): Enhance mission creation

### DIFF
--- a/lib/presentation/views/control_mission/widgets/create_mission_widget.dart
+++ b/lib/presentation/views/control_mission/widgets/create_mission_widget.dart
@@ -325,8 +325,8 @@ class CreateMissionScreen extends GetView<CreateControlMissionController> {
                                   .last
                                   .toString(),
                             ),
-                            6,
-                            30,
+                            9,
+                            1,
                           ),
                         ).then(
                           (picked) {


### PR DESCRIPTION
Increase the default values for the start and end hour inputs
in the create mission screen to provide more flexibility for
users when setting mission times.