### PR TITLE
✨ feat(side-menu): Persist side menu index in Hive

### DIFF
--- a/lib/domain/services/side_menue_get_controller.dart
+++ b/lib/domain/services/side_menue_get_controller.dart
@@ -4,6 +4,7 @@ import 'package:easy_sidemenu/easy_sidemenu.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../Data/Models/app_menue_item_model.dart';
 import '../../presentation/resource_manager/ReusableWidget/show_dialgue.dart';
@@ -19,6 +20,7 @@ class SideMenueGetController extends GetxController {
   List<SideMenuItem> userMenue = [];
 
   changePage(int currentIndex) {
+    Hive.box('SideMenueIndex').put('index', currentIndex);
     sideMenuController.changePage(currentIndex);
   }
 
@@ -90,8 +92,10 @@ class SideMenueGetController extends GetxController {
 
   @override
   void onInit() {
-    sideMenuController = SideMenuController();
     super.onInit();
+    sideMenuController = SideMenuController(
+      initialPage: Hive.box('SideMenueIndex').get('index') ?? nowIndex,
+    );
   }
 
   onRouteChange(String name) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ Future<void> main() async {
     Hive.openBox('Profile'), // Id   --- profile
     Hive.openBox('ControlMission'),
     Hive.openBox('ExamRoom'),
+    Hive.openBox('SideMenueIndex'),
   ]);
   runApp(MyApp());
 }


### PR DESCRIPTION
The changes in this commit add functionality to persist the current side menu
index in Hive. This ensures that the user's last selected side menu item is
remembered and restored when the app is reopened.

The main changes include:

- Opening a new Hive box named 'SideMenueIndex' to store the current side menu
  index
- Storing the current side menu index when the user changes the page
- Initializing the SideMenuController with the stored side menu index, or the
  default index if no value is found in Hive

This improvement enhances the user experience by providing a more consistent
and seamless navigation experience within the app.