### PR TITLE
⚡️ refactor(student_controllers): remove unnecessary school ID

### DIFF
--- a/lib/domain/controllers/batch_documents.dart/cover_sheets_controller.dart
+++ b/lib/domain/controllers/batch_documents.dart/cover_sheets_controller.dart
@@ -352,7 +352,7 @@ class CoversSheetsController extends GetxController {
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
 
     var response = await responseHandler.getResponse(
-      path: "${GradeLinks.gradesSchools}/$schoolId",
+      path: GradeLinks.gradesSchools,
       converter: GradesResModel.fromJson,
       type: ReqTypeEnum.GET,
     );

--- a/lib/domain/controllers/batch_documents.dart/create_covers_sheets_controller.dart
+++ b/lib/domain/controllers/batch_documents.dart/create_covers_sheets_controller.dart
@@ -172,7 +172,7 @@ class CreateCoversSheetsController extends GetxController {
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
 
     var response = await responseHandler.getResponse(
-      path: "${GradeLinks.gradesSchools}/$schoolId",
+      path: GradeLinks.gradesSchools,
       converter: GradesResModel.fromJson,
       type: ReqTypeEnum.GET,
     );

--- a/lib/domain/controllers/batch_documents.dart/seat_number_controller.dart
+++ b/lib/domain/controllers/batch_documents.dart/seat_number_controller.dart
@@ -181,7 +181,7 @@ class SeatNumberController extends GetxController {
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
 
     var response = await responseHandler.getResponse(
-      path: "${GradeLinks.gradesSchools}/$schoolId",
+      path: GradeLinks.gradesSchools,
       converter: GradesResModel.fromJson,
       type: ReqTypeEnum.GET,
     );

--- a/lib/domain/controllers/control_mission/add_new_students_to_control_mission.dart
+++ b/lib/domain/controllers/control_mission/add_new_students_to_control_mission.dart
@@ -91,12 +91,11 @@ class AddNewStudentsToControlMissionController extends GetxController {
   Future<bool> getGrades() async {
     bool gotData = false;
     update();
-    int schoolId = Hive.box('School').get('Id');
 
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
     Either<Failure, GradesResModel> response =
         await responseHandler.getResponse(
-      path: "${GradeLinks.gradesSchools}/$schoolId",
+      path: GradeLinks.gradesSchools,
       converter: GradesResModel.fromJson,
       type: ReqTypeEnum.GET,
     );

--- a/lib/domain/controllers/control_mission/create_control_mission.dart
+++ b/lib/domain/controllers/control_mission/create_control_mission.dart
@@ -196,12 +196,11 @@ class CreateControlMissionController extends GetxController {
   Future<bool> getGrades() async {
     bool gotData = false;
     update();
-    int schoolId = Hive.box('School').get('Id');
 
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
     Either<Failure, GradesResModel> response =
         await responseHandler.getResponse(
-      path: "${GradeLinks.gradesSchools}/$schoolId",
+      path: GradeLinks.gradesSchools,
       converter: GradesResModel.fromJson,
       type: ReqTypeEnum.GET,
     );

--- a/lib/domain/controllers/students_controllers/add_new_student_controller.dart
+++ b/lib/domain/controllers/students_controllers/add_new_student_controller.dart
@@ -89,7 +89,6 @@ class AddNewStudentController extends GetxController {
     update();
     bool cohortHasBeenAdded = false;
 
-    int selectedSchoolId = Hive.box('School').get('SchoolTypeID');
     ResponseHandler<CohortsResModel> responseHandler = ResponseHandler();
 
     var response = await responseHandler.getResponse(
@@ -120,7 +119,6 @@ class AddNewStudentController extends GetxController {
     update();
     bool gradeHasBeenAdded = false;
 
-    int schoolId = Hive.box('School').get('Id');
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
 
     var response = await responseHandler.getResponse(
@@ -151,7 +149,6 @@ class AddNewStudentController extends GetxController {
     update();
     bool classRoomHasBeenAdded = false;
 
-    int schoolId = Hive.box('School').get('Id');
     ResponseHandler<ClassesRoomsResModel> responseHandler = ResponseHandler();
 
     var response = await responseHandler.getResponse(

--- a/lib/domain/controllers/students_controllers/student_controller.dart
+++ b/lib/domain/controllers/students_controllers/student_controller.dart
@@ -419,12 +419,11 @@ class StudentController extends GetxController {
   Future<bool> getGrades() async {
     bool gotData = false;
     update();
-    int schoolId = Hive.box('School').get('Id');
 
     ResponseHandler<GradesResModel> responseHandler = ResponseHandler();
     Either<Failure, GradesResModel> response =
         await responseHandler.getResponse(
-      path: "${GradeLinks.gradesSchools}/$schoolId",
+      path: GradeLinks.gradesSchools,
       converter: GradesResModel.fromJson,
       type: ReqTypeEnum.GET,
     );


### PR DESCRIPTION
retrieval from Hive

The changes in this commit remove the retrieval of school ID from the Hive
box in the `AddNewStudentController`, `StudentController`,
`AddNewStudentsToControlMissionController`, and `CreateControlMissionController`.
Instead, the code now directly uses the `GradeLinks.gradesSchools` endpoint to
fetch the grades data, eliminating the need for the school ID.

This change simplifies the code and reduces the amount of data being stored
and retrieved from Hive, making the application more efficient and
maintainable.