### PR TITLE
♻️ refactor(routes): delete RolesController on route exit

### DIFF
--- a/lib/presentation/resource_manager/routes/app_go_router.dart
+++ b/lib/presentation/resource_manager/routes/app_go_router.dart
@@ -292,6 +292,7 @@ class AppGoRouter {
           return const RolesScreen();
         },
         onExit: (context, state) {
+          Get.delete<RolesController>();
           return true;
         },
       ),


### PR DESCRIPTION
Removes the RolesController instance when exiting the RolesScreen route
to prevent memory leaks and improve performance.