### PR TITLE
🔧 feat(SideMenueWidget): Enhance tooltip and hover styles

### DIFF
--- a/lib/presentation/views/side_menue/side_menue.dart
+++ b/lib/presentation/views/side_menue/side_menue.dart
@@ -22,7 +22,6 @@ class SideMenueWidget extends GetView<SideMenueGetController> {
         showTooltip: true,
         hoverColor: ColorManager.darkGrey,
         selectedHoverColor: ColorManager.darkGrey,
-      c
         selectedTitleTextStyle: nunitoBoldStyle(
           color: ColorManager.white,
           fontSize: AppSize.s16,


### PR DESCRIPTION
Improves the tooltip and hover styles of the SideMenueWidget to provide a
better user experience. Removes an unnecessary line and updates the
selectedTitleTextStyle to use the nunitoBoldStyle with a white color and
font size of 16.