### PR TITLE
✨ feat(pubspec.lock): update dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,11 +141,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.0.1"
-      resolved-ref: cda46dd5422f26c5e73c0d574d80da186e0da802
+      ref: "v1.0.2"
+      resolved-ref: "926ccd6ac59c93a6ca871f94ba4d3048acf9268a"
       url: "https://github.com/Mahmoud-Saeed-Mahmoud/custom_theme.git"
     source: git
-    version: "0.0.2"
+    version: "0.0.3"
   dartz:
     dependency: "direct main"
     description:
@@ -341,18 +341,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -405,18 +405,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   multi_dropdown:
     dependency: "direct main"
     description:
@@ -658,10 +658,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   transformable_list_view:
     dependency: "direct main"
     description:
@@ -770,10 +770,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   custom_theme:
     git:
       url: https://github.com/Mahmoud-Saeed-Mahmoud/custom_theme.git
-      ref: v1.0.1
+      ref: v1.0.2
   package_info_plus: ^8.0.2
 
 dev_dependencies:


### PR DESCRIPTION
    
Upgrades the following dependencies:
    
- `test_api` from `0.7.0` to `0.7.2`
- `custom_theme` from `0.0.2` to `0.0.3`
- `vm_service` from `14.2.1` to `14.2.5`
- `material_color_utilities` from `0.8.0` to `0.11.1`
- `meta` from `1.12.0` to `1.15.0`
- `leak_tracker` from `10.0.4` to `10.0.5`
- `leak_tracker_flutter_testing` from `3.0.3` to `3.0.5`
    
The changes in the dependencies are necessary to ensure the project
remains up-to-date and secure, and to provide access to the latest
features and bug fixes.