### PR TITLE
✨ feat(school_controller): Allow nullable `selectedItem`

### DIFF
--- a/lib/domain/controllers/school_controller.dart
+++ b/lib/domain/controllers/school_controller.dart
@@ -250,7 +250,7 @@ class SchoolController extends GetxController {
     await Hive.box('School').flush();
   }
 
-  void setSelectedItem(ValueItem item) {
+  void setSelectedItem(ValueItem? item) {
     selectedItem = item;
     update();
   }

--- a/lib/presentation/views/schools/Widgets/add_new_school.dart
+++ b/lib/presentation/views/schools/Widgets/add_new_school.dart
@@ -71,7 +71,8 @@ class AddNewSchoolWidget extends GetView<SchoolController> {
               width: 500,
               child: MultiSelectDropDownView(
                 onOptionSelected: (selectedItem) {
-                  controller.setSelectedItem(selectedItem[0]);
+                  controller.setSelectedItem(
+                      selectedItem.isEmpty ? null : selectedItem.first);
                 },
                 options: controller.options,
               ),


### PR DESCRIPTION
Updates the `setSelectedItem` function in the `SchoolController` to
accept a nullable `ValueItem` parameter. This allows the `selectedItem`
to be set to `null`, which may be useful in certain scenarios.

Additionally, updates the `AddNewSchoolWidget` to handle the case where
the `MultiSelectDropDownView` returns an empty list, by setting the
`selectedItem` to `null` in this case.