### PR TITLE
feat(🎨): Enhance side menu storage handling

### DIFF
--- a/lib/presentation/views/side_menue/side_menue.dart
+++ b/lib/presentation/views/side_menue/side_menue.dart
@@ -17,6 +17,7 @@ class SideMenueWidget extends GetView<SideMenueGetController> {
   Widget build(BuildContext context) {
     return PageStorage(
       bucket: controller.sideMenuBucket,
+      key: controller.sideMenuStorageKey,
       child: SideMenu(
         showToggle: true,
         controller: controller.sideMenuController,
@@ -69,7 +70,6 @@ class SideMenueWidget extends GetView<SideMenueGetController> {
           ],
         ),
         items: controller.getUserMenue(context),
-        key: controller.sideMenuStorageKey,
       ),
     );
   }


### PR DESCRIPTION
Adds a `key` parameter to the `PageStorage` widget in the `SideMenueWidget`
to enable better state management and persistence of the side menu. This
ensures that the side menu state is properly stored and restored when the
widget is rebuilt, providing a more seamless user experience.