### PR TITLE
✨ feat: Add students' grades to control mission review

### DIFF
--- a/lib/Data/Models/student/student_grades_res_model.dart
+++ b/lib/Data/Models/student/student_grades_res_model.dart
@@ -1,14 +1,30 @@
-import '../barcodes/barcode_res_model.dart';
-import '../class_room/class_room_res_model.dart';
+class Barcode {
+  int? id;
+  String? studentDegree;
+
+  Barcode({this.id, this.studentDegree});
+
+  Barcode.fromJson(Map<String, dynamic> json) {
+    id = json['ID'];
+    studentDegree = json['StudentDegree'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['ID'] = id;
+    data['StudentDegree'] = studentDegree;
+    return data;
+  }
+}
 
 class Cohort {
+  int? iD;
+  String? name;
   List<CohortHasSubjects>? cohortHasSubjects;
 
-  int? iD;
-
-  String? name;
   Cohort({this.iD, this.name, this.cohortHasSubjects});
-  Cohort.fromJson(json) {
+
+  Cohort.fromJson(Map<String, dynamic> json) {
     iD = json['ID'];
     name = json['Name'];
     if (json['cohort_has_subjects'] != null) {
@@ -32,43 +48,19 @@ class Cohort {
 }
 
 class CohortHasSubjects {
-  ExamRoom? subjects;
+  Grades? subjects;
 
   CohortHasSubjects({this.subjects});
 
-  CohortHasSubjects.fromJson(json) {
+  CohortHasSubjects.fromJson(Map<String, dynamic> json) {
     subjects =
-        json['subjects'] != null ? ExamRoom.fromJson(json['subjects']) : null;
+        json['subjects'] != null ? Grades.fromJson(json['subjects']) : null;
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
     if (subjects != null) {
       data['subjects'] = subjects!.toJson();
-    }
-    return data;
-  }
-}
-
-class ExamMission {
-  ExamRoom? grades;
-
-  ExamRoom? subjects;
-
-  ExamMission({this.subjects, this.grades});
-  ExamMission.fromJson(json) {
-    subjects =
-        json['subjects'] != null ? ExamRoom.fromJson(json['subjects']) : null;
-    grades = json['grades'] != null ? ExamRoom.fromJson(json['grades']) : null;
-  }
-
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
-    if (subjects != null) {
-      data['subjects'] = subjects!.toJson();
-    }
-    if (grades != null) {
-      data['grades'] = grades!.toJson();
     }
     return data;
   }
@@ -76,11 +68,60 @@ class ExamMission {
 
 class ExamRoom {
   int? iD;
+  String? name;
+  List<StudentSeatNumnbers>? studentSeatNumnbers;
 
+  ExamRoom({this.iD, this.name, this.studentSeatNumnbers});
+
+  ExamRoom.fromJson(Map<String, dynamic> json) {
+    iD = json['ID'];
+    name = json['Name'];
+    if (json['student_seat_numnbers'] != null) {
+      studentSeatNumnbers = <StudentSeatNumnbers>[];
+      json['student_seat_numnbers'].forEach((v) {
+        studentSeatNumnbers!.add(StudentSeatNumnbers.fromJson(v));
+      });
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['ID'] = iD;
+    data['Name'] = name;
+    if (studentSeatNumnbers != null) {
+      data['student_seat_numnbers'] =
+          studentSeatNumnbers!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class Grades {
+  int? iD;
   String? name;
 
-  ExamRoom({this.iD, this.name});
-  ExamRoom.fromJson(json) {
+  Grades({this.iD, this.name});
+
+  Grades.fromJson(Map<String, dynamic> json) {
+    iD = json['ID'];
+    name = json['Name'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['ID'] = iD;
+    data['Name'] = name;
+    return data;
+  }
+}
+
+class SchoolClass {
+  int? iD;
+  String? name;
+
+  SchoolClass({this.iD, this.name});
+
+  SchoolClass.fromJson(Map<String, dynamic> json) {
     iD = json['ID'];
     name = json['Name'];
   }
@@ -94,30 +135,39 @@ class ExamRoom {
 }
 
 class Student {
-  ClassRoomResModel? classRoom;
-
-  Cohort? cohort;
-
   String? firstName;
-  int? iD;
   String? secondName;
   String? thirdName;
-  Student(
-      {this.firstName,
-      this.secondName,
-      this.thirdName,
-      this.iD,
-      this.cohort,
-      this.classRoom});
-  Student.fromJson(json) {
+  Grades? grades;
+  SchoolClass? schoolClass;
+  Cohort? cohort;
+  Barcode? barcode;
+
+  Student({
+    this.firstName,
+    this.secondName,
+    this.thirdName,
+    this.grades,
+    this.schoolClass,
+    this.cohort,
+    this.barcode,
+  });
+
+  Student.fromJson(Map<String, dynamic> json) {
     firstName = json['First_Name'];
     secondName = json['Second_Name'];
     thirdName = json['Third_Name'];
-    iD = json['ID'];
-    cohort = json['cohort'] != null ? Cohort.fromJson(json['cohort']) : null;
-    classRoom = json['school_class'] != null
-        ? ClassRoomResModel.fromJson(json['school_class'])
+    grades = json['grades'] != null ? Grades.fromJson(json['grades']) : null;
+    schoolClass = json['school_class'] != null
+        ? SchoolClass.fromJson(json['school_class'])
         : null;
+    cohort = json['cohort'] != null ? Cohort.fromJson(json['cohort']) : null;
+    if (json['student_barcode'] != null &&
+        (json['student_barcode'] as List).isNotEmpty) {
+      barcode = Barcode.fromJson(json['student_barcode'][0]);
+    } else {
+      barcode = null;
+    }
   }
 
   Map<String, dynamic> toJson() {
@@ -125,42 +175,32 @@ class Student {
     data['First_Name'] = firstName;
     data['Second_Name'] = secondName;
     data['Third_Name'] = thirdName;
-    data['ID'] = iD;
+    if (grades != null) {
+      data['grades'] = grades!.toJson();
+    }
+    if (schoolClass != null) {
+      data['school_class'] = schoolClass!.toJson();
+    }
     if (cohort != null) {
       data['cohort'] = cohort!.toJson();
     }
-    if (classRoom != null) {
-      data['school_class'] = classRoom!.toJson();
+    if (barcode != null) {
+      data['student_barcode'] = barcode!.toJson();
     }
     return data;
   }
 }
 
 class StudentGradesResModel {
-  List<ExamMission>? examMission;
-
   List<ExamRoom>? examRoom;
 
-  List<StudentSeatNumnbers>? studentSeatNumnbers;
-  StudentGradesResModel(
-      {this.examRoom, this.examMission, this.studentSeatNumnbers});
+  StudentGradesResModel({this.examRoom});
+
   StudentGradesResModel.fromJson(json) {
     if (json['exam_room'] != null) {
       examRoom = <ExamRoom>[];
       json['exam_room'].forEach((v) {
         examRoom!.add(ExamRoom.fromJson(v));
-      });
-    }
-    if (json['exam_mission'] != null) {
-      examMission = <ExamMission>[];
-      json['exam_mission'].forEach((v) {
-        examMission!.add(ExamMission.fromJson(v));
-      });
-    }
-    if (json['student_seat_numnbers'] != null) {
-      studentSeatNumnbers = <StudentSeatNumnbers>[];
-      json['student_seat_numnbers'].forEach((v) {
-        studentSeatNumnbers!.add(StudentSeatNumnbers.fromJson(v));
       });
     }
   }
@@ -170,39 +210,30 @@ class StudentGradesResModel {
     if (examRoom != null) {
       data['exam_room'] = examRoom!.map((v) => v.toJson()).toList();
     }
-    if (examMission != null) {
-      data['exam_mission'] = examMission!.map((v) => v.toJson()).toList();
-    }
-    if (studentSeatNumnbers != null) {
-      data['student_seat_numnbers'] =
-          studentSeatNumnbers!.map((v) => v.toJson()).toList();
-    }
     return data;
   }
 }
 
 class StudentSeatNumnbers {
-  List<BarcodeResModel>? barcode;
-
+  int? iD;
+  String? seatNumber;
   Student? student;
 
-  StudentSeatNumnbers({this.student, this.barcode});
-  StudentSeatNumnbers.fromJson(json) {
+  StudentSeatNumnbers({this.iD, this.seatNumber, this.student});
+
+  StudentSeatNumnbers.fromJson(Map<String, dynamic> json) {
+    iD = json['ID'];
+    seatNumber = json['Seat_Number'];
     student =
         json['student'] != null ? Student.fromJson(json['student']) : null;
-    barcode = List<BarcodeResModel>.from(
-      json['student_barcode']
-          .map((student) => BarcodeResModel.fromJson(student)),
-    );
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
+    data['ID'] = iD;
+    data['Seat_Number'] = seatNumber;
     if (student != null) {
       data['student'] = student!.toJson();
-    }
-    if (barcode != null) {
-      data['student_barcode'] = barcode!.map((v) => v.toJson()).toList();
     }
     return data;
   }

--- a/lib/domain/controllers/control_mission/review_control_mission_controller.dart
+++ b/lib/domain/controllers/control_mission/review_control_mission_controller.dart
@@ -49,77 +49,142 @@ class DetailsAndReviewMissionController extends GetxController {
   List<PlutoRow> studentsSeatNumbersRows = <PlutoRow>[];
   TabController? tabController;
 
+  Future<bool> activeStudentInControlMission({required String idSeat}) async {
+    bool activateStudents = false;
+    update();
+    ResponseHandler<void> responseHandler = ResponseHandler<void>();
+    Either<Failure, void> response = await responseHandler.getResponse(
+      path: '${StudentsLinks.studentSeatNumberActive}/$idSeat',
+      converter: (_) {},
+      type: ReqTypeEnum.PATCH,
+      body: {},
+    );
+    response.fold(
+      (l) {
+        MyAwesomeDialogue(
+          title: 'Error',
+          desc: l.message,
+          dialogType: DialogType.error,
+        ).showDialogue(Get.key.currentContext!);
+        activateStudents = false;
+      },
+      (r) {
+        activateStudents = true;
+        getStudentsSeatNumberByControlMissionId();
+      },
+    );
+    update();
+    return activateStudents;
+  }
+
   void convertStudentsGradesToPlutoGridRows() {
     studentsGradesRows.clear();
 
     if (studentGradesResModel != null) {
-      for (var studentSeatNumber
-          in studentGradesResModel!.studentSeatNumnbers!) {
-        studentsGradesRows.add(
-          PlutoRow(
-            cells: {
-              'name_field': PlutoCell(
-                  value:
-                      '${studentSeatNumber.student?.firstName} ${studentSeatNumber.student?.secondName} ${studentSeatNumber.student?.thirdName}'),
-              'grade_field': PlutoCell(
-                  value:
-                      '${studentGradesResModel?.examMission?.first.grades?.name}'),
-              'class_field': PlutoCell(
-                  value: '${studentSeatNumber.student?.classRoom?.name}'),
-              'exam_room_field': PlutoCell(
-                  value: '${studentGradesResModel?.examRoom?.first.name}'),
-              ...Map.fromEntries(
-                List.generate(
-                  studentGradesResModel!.studentSeatNumnbers!
-                      .map(
-                        (element) =>
-                            element.student!.cohort!.cohortHasSubjects!.map(
-                          (element) =>
-                              (element.subjects!.name, element.subjects!.iD),
-                        ),
-                      )
-                      .expand((element) => element)
-                      .toSet()
-                      .toList()
-                      .length,
-                  (index) {
-                    final subject = studentGradesResModel!.studentSeatNumnbers!
+      for (var examRoom in studentGradesResModel!.examRoom!) {
+        for (var studentSeatNumber in examRoom.studentSeatNumnbers!) {
+          studentsGradesRows.add(
+            PlutoRow(
+              cells: {
+                'name_field': PlutoCell(
+                    value:
+                        '${studentSeatNumber.student?.firstName} ${studentSeatNumber.student?.secondName} ${studentSeatNumber.student?.thirdName}'),
+                'grade_field': PlutoCell(
+                    value: '${studentSeatNumber.student?.grades?.name}'),
+                'class_field': PlutoCell(
+                    value: '${studentSeatNumber.student?.schoolClass?.name}'),
+                'exam_room_field': PlutoCell(value: '${examRoom.name}'),
+                ...Map.fromEntries(
+                  List.generate(
+                    studentGradesResModel!.examRoom!
                         .map(
-                          (element) =>
-                              element.student!.cohort!.cohortHasSubjects!.map(
-                            (element) => (
-                              name: element.subjects!.name,
-                              id: element.subjects!.iD
+                          (element) => element.studentSeatNumnbers!.map(
+                            (element) =>
+                                element.student!.cohort!.cohortHasSubjects!.map(
+                              (element) => (
+                                element.subjects!.name,
+                                element.subjects!.iD
+                              ),
                             ),
                           ),
                         )
                         .expand((element) => element)
+                        .expand((element) => element)
                         .toSet()
-                        .toList()[index];
-                    return MapEntry(
-                      "${subject.name}_${subject.id}",
-                      PlutoCell(
-                          value: studentSeatNumber
-                                  .student!.cohort!.cohortHasSubjects!
-                                  .map((element) => element.subjects!.name)
-                                  .contains(subject.name)
-                              ? studentSeatNumber
-                                          .barcode!.first.studentDegree ==
-                                      null
-                                  ? 'Need to scan'
-                                  : '${studentSeatNumber.barcode!.first.studentDegree}'
-                              : 'Exampt'),
-                    );
-                  },
+                        .toList()
+                        .length,
+                    (index) {
+                      final ({String? name, int? id}) subject =
+                          studentGradesResModel!.examRoom!
+                              .map(
+                                (element) => element.studentSeatNumnbers!.map(
+                                  (element) => element
+                                      .student!.cohort!.cohortHasSubjects!
+                                      .map(
+                                    (element) => (
+                                      name: element.subjects!.name,
+                                      id: element.subjects!.iD
+                                    ),
+                                  ),
+                                ),
+                              )
+                              .expand((element) => element)
+                              .expand((element) => element)
+                              .toSet()
+                              .toList()[index];
+                      return MapEntry(
+                        "${subject.name}_${subject.id}",
+                        PlutoCell(
+                            value: studentSeatNumber
+                                    .student!.cohort!.cohortHasSubjects!
+                                    .map((element) => element.subjects!.name)
+                                    .contains(subject.name)
+                                ? studentSeatNumber
+                                            .student?.barcode?.studentDegree ==
+                                        null
+                                    ? 'Need to scan'
+                                    : '${studentSeatNumber.student?.barcode?.studentDegree}'
+                                : 'Exampt'),
+                      );
+                    },
+                  ),
                 ),
-              ),
-            },
-          ),
-        );
+              },
+            ),
+          );
+        }
       }
     }
     studentsGradesPlutoGridStateManager!.setPage(1);
     return;
+  }
+
+  Future<bool> deactiveStudentInControlMission({required String idSeat}) async {
+    bool deactivateStudents = false;
+    update();
+    ResponseHandler<void> responseHandler = ResponseHandler<void>();
+    Either<Failure, void> response = await responseHandler.getResponse(
+      path: '${StudentsLinks.studentSeatNumberDeactive}/$idSeat',
+      converter: (_) {},
+      type: ReqTypeEnum.PATCH,
+      body: {},
+    );
+    response.fold(
+      (l) {
+        MyAwesomeDialogue(
+          title: 'Error',
+          desc: l.message,
+          dialogType: DialogType.error,
+        ).showDialogue(Get.key.currentContext!);
+        deactivateStudents = false;
+      },
+      (r) {
+        deactivateStudents = true;
+        getStudentsSeatNumberByControlMissionId();
+      },
+    );
+    update();
+    return deactivateStudents;
   }
 
   void exportStudentDegreesToExcel(BuildContext context) {
@@ -131,27 +196,37 @@ class DetailsAndReviewMissionController extends GetxController {
       'Class',
       'Exam Room',
       ...List.generate(
-        studentGradesResModel!.studentSeatNumnbers!
+        studentGradesResModel!.examRoom!
             .map(
-              (element) => element.student!.cohort!.cohortHasSubjects!.map(
-                (element) => (element.subjects!.name, element.subjects!.iD),
+              (element) => element.studentSeatNumnbers!.map(
+                (element) => element.student!.cohort!.cohortHasSubjects!.map(
+                  (element) => (element.subjects!.name, element.subjects!.iD),
+                ),
               ),
             )
+            .expand((element) => element)
             .expand((element) => element)
             .toSet()
             .toList()
             .length,
         (index) {
-          final subject = studentGradesResModel!.studentSeatNumnbers!
-              .map(
-                (element) => element.student!.cohort!.cohortHasSubjects!.map(
-                  (element) =>
-                      (name: element.subjects!.name, id: element.subjects!.iD),
-                ),
-              )
-              .expand((element) => element)
-              .toSet()
-              .toList()[index];
+          final ({String? name, int? id}) subject =
+              studentGradesResModel!.examRoom!
+                  .map(
+                    (element) => element.studentSeatNumnbers!.map(
+                      (element) =>
+                          element.student!.cohort!.cohortHasSubjects!.map(
+                        (element) => (
+                          name: element.subjects!.name,
+                          id: element.subjects!.iD
+                        ),
+                      ),
+                    ),
+                  )
+                  .expand((element) => element)
+                  .expand((element) => element)
+                  .toSet()
+                  .toList()[index];
           return subject.name!;
         },
       )
@@ -198,27 +273,37 @@ class DetailsAndReviewMissionController extends GetxController {
       'Class',
       'Exam Room',
       ...List.generate(
-        studentGradesResModel!.studentSeatNumnbers!
+        studentGradesResModel!.examRoom!
             .map(
-              (element) => element.student!.cohort!.cohortHasSubjects!.map(
-                (element) => (element.subjects!.name, element.subjects!.iD),
+              (element) => element.studentSeatNumnbers!.map(
+                (element) => element.student!.cohort!.cohortHasSubjects!.map(
+                  (element) => (element.subjects!.name, element.subjects!.iD),
+                ),
               ),
             )
+            .expand((element) => element)
             .expand((element) => element)
             .toSet()
             .toList()
             .length,
         (index) {
-          final subject = studentGradesResModel!.studentSeatNumnbers!
-              .map(
-                (element) => element.student!.cohort!.cohortHasSubjects!.map(
-                  (element) =>
-                      (name: element.subjects!.name, id: element.subjects!.iD),
-                ),
-              )
-              .expand((element) => element)
-              .toSet()
-              .toList()[index];
+          final ({String? name, int? id}) subject =
+              studentGradesResModel!.examRoom!
+                  .map(
+                    (element) => element.studentSeatNumnbers!.map(
+                      (element) =>
+                          element.student!.cohort!.cohortHasSubjects!.map(
+                        (element) => (
+                          name: element.subjects!.name,
+                          id: element.subjects!.iD
+                        ),
+                      ),
+                    ),
+                  )
+                  .expand((element) => element)
+                  .expand((element) => element)
+                  .toSet()
+                  .toList()[index];
           return subject.name!;
         },
       )
@@ -528,62 +613,6 @@ class DetailsAndReviewMissionController extends GetxController {
     isLodingGetSubjects = false;
   }
 
-  Future<bool> activeStudentInControlMission({required String idSeat}) async {
-    bool activateStudents = false;
-    update();
-    ResponseHandler<void> responseHandler = ResponseHandler<void>();
-    Either<Failure, void> response = await responseHandler.getResponse(
-      path: '${StudentsLinks.studentSeatNumberActive}/$idSeat',
-      converter: (_) {},
-      type: ReqTypeEnum.PATCH,
-      body: {},
-    );
-    response.fold(
-      (l) {
-        MyAwesomeDialogue(
-          title: 'Error',
-          desc: l.message,
-          dialogType: DialogType.error,
-        ).showDialogue(Get.key.currentContext!);
-        activateStudents = false;
-      },
-      (r) {
-        activateStudents = true;
-        getStudentsSeatNumberByControlMissionId();
-      },
-    );
-    update();
-    return activateStudents;
-  }
-
-  Future<bool> deactiveStudentInControlMission({required String idSeat}) async {
-    bool deactivateStudents = false;
-    update();
-    ResponseHandler<void> responseHandler = ResponseHandler<void>();
-    Either<Failure, void> response = await responseHandler.getResponse(
-      path: '${StudentsLinks.studentSeatNumberDeactive}/$idSeat',
-      converter: (_) {},
-      type: ReqTypeEnum.PATCH,
-      body: {},
-    );
-    response.fold(
-      (l) {
-        MyAwesomeDialogue(
-          title: 'Error',
-          desc: l.message,
-          dialogType: DialogType.error,
-        ).showDialogue(Get.key.currentContext!);
-        deactivateStudents = false;
-      },
-      (r) {
-        deactivateStudents = true;
-        getStudentsSeatNumberByControlMissionId();
-      },
-    );
-    update();
-    return deactivateStudents;
-  }
-
   @override
   void onInit() async {
     super.onInit();
@@ -594,6 +623,7 @@ class DetailsAndReviewMissionController extends GetxController {
     getExamRoomByControlMissionId();
     getSubjectByControlMissionId();
     getStudentsSeatNumberByControlMissionId();
+    controlMissionId != 0 ? getStudentsGrades() : null;
   }
 
   Future<void> saveControlMissionId(int id) async {

--- a/lib/presentation/views/control_mission/widgets/review_widget.dart
+++ b/lib/presentation/views/control_mission/widgets/review_widget.dart
@@ -82,61 +82,75 @@ class ReviewWidget extends GetView<DetailsAndReviewMissionController> {
                               type: PlutoColumnType.text(),
                             ),
                             ...List.generate(
-                              completeMissionsController
-                                  .studentGradesResModel!.studentSeatNumnbers!
+                              controller.studentGradesResModel!.examRoom!
                                   .map(
-                                    (element) => element
-                                        .student!.cohort!.cohortHasSubjects!
-                                        .map(
-                                      (element) => (
-                                        element.subjects!.name,
-                                        element.subjects!.iD
+                                    (element) =>
+                                        element.studentSeatNumnbers!.map(
+                                      (element) => element
+                                          .student!.cohort!.cohortHasSubjects!
+                                          .map(
+                                        (element) => (
+                                          element.subjects!.name,
+                                          element.subjects!.iD
+                                        ),
                                       ),
                                     ),
                                   )
+                                  .expand((element) => element)
                                   .expand((element) => element)
                                   .toSet()
                                   .toList()
                                   .length,
                               (index) {
-                                final subject = completeMissionsController
-                                    .studentGradesResModel!.studentSeatNumnbers!
-                                    .map(
-                                      (element) => element
-                                          .student!.cohort!.cohortHasSubjects!
-                                          .map(
-                                        (element) => (
-                                          name: element.subjects!.name,
-                                          id: element.subjects!.iD
-                                        ),
-                                      ),
-                                    )
-                                    .expand((element) => element)
-                                    .toSet()
-                                    .toList()[index];
+                                final ({String? name, int? id}) subject =
+                                    controller.studentGradesResModel!.examRoom!
+                                        .map(
+                                          (element) =>
+                                              element.studentSeatNumnbers!.map(
+                                            (element) => element.student!
+                                                .cohort!.cohortHasSubjects!
+                                                .map(
+                                              (element) => (
+                                                name: element.subjects!.name,
+                                                id: element.subjects!.iD
+                                              ),
+                                            ),
+                                          ),
+                                        )
+                                        .expand((element) => element)
+                                        .expand((element) => element)
+                                        .toSet()
+                                        .toList()[index];
                                 return PlutoColumn(
                                   readOnly: true,
                                   enableEditingMode: false,
-                                  title: subject.name!,
+                                  title: subject.name ?? '',
                                   field: "${subject.name}_${subject.id}",
                                   type: PlutoColumnType.text(),
                                   footerRenderer: index ==
                                           completeMissionsController
                                                   .studentGradesResModel!
-                                                  .studentSeatNumnbers!
+                                                  .examRoom!
                                                   .map(
                                                     (element) => element
-                                                        .student!
-                                                        .cohort!
-                                                        .cohortHasSubjects!
+                                                        .studentSeatNumnbers!
                                                         .map(
                                                       (element) => (
-                                                        element.subjects!.name,
-                                                        element.subjects!.iD
+                                                        element.student!.cohort!
+                                                            .cohortHasSubjects!
+                                                            .map(
+                                                          (element) => (
+                                                            element
+                                                                .subjects?.name,
+                                                            element.subjects?.iD
+                                                          ),
+                                                        ),
                                                       ),
                                                     ),
                                                   )
                                                   .expand((element) => element)
+                                                  .expand(
+                                                      (element) => element.$1)
                                                   .toSet()
                                                   .toList()
                                                   .length -

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -341,18 +341,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -405,18 +405,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   multi_dropdown:
     dependency: "direct main"
     description:
@@ -658,10 +658,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   transformable_list_view:
     dependency: "direct main"
     description:
@@ -770,10 +770,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
This change adds the ability to fetch and display students' grades in the
control mission review page. Previously, only the exam room and student seat
numbers were being fetched. This change adds the functionality to fetch the
students' grades and display them in the table.

The key changes are:

1. Added a new method `getStudentsGrades()` in the
   `DetailsAndReviewMissionController` to fetch the students' grades from the
   backend.
2. Updated the `Student` model to include a `grades` field, which is a
   `Grades` object.
3. Updated the table generation logic in the
   `DetailsAndReviewMissionController` to include the students' grades in the
   table.

These changes will provide a more comprehensive view of the control mission
review, allowing users to see the students' grades along with the other
relevant information.