### PR TITLE
🎨 feat(firebase): enable web frameworks experiment

### DIFF
--- a/.github/workflows/deploy_web_app_to_firebase.yml
+++ b/.github/workflows/deploy_web_app_to_firebase.yml
@@ -17,6 +17,12 @@ jobs:
       - run: flutter build web
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
+      - name: Enable webframeworks experiment
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          firebase experiments:enable webframeworks --token $FIREBASE_TOKEN
+
       - name: Deploy to Firebase
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
Enables the web frameworks experiment in the Firebase CLI to improve
the deployment of the web application to Firebase Hosting. This
feature is necessary to take advantage of the latest improvements
in the web deployment process provided by Firebase.