### PR TITLE
♻️ refactor(TokenInterceptor): Update baseUrl and handle network errors

### DIFF
--- a/lib/app/configurations/token_interceptor.dart
+++ b/lib/app/configurations/token_interceptor.dart
@@ -17,11 +17,10 @@ class TokenInterceptor extends Interceptor {
       String refresh = tokenService.tokenModel!.rToken;
       var dio = Dio(
         BaseOptions(
-          baseUrl: AppLinks.baseUrlDev,
+          baseUrl: AppLinks.baseUrlProd,
         ),
       );
 
-      // DioException Error in the networklayer can not be resolved by the library
       var response = await dio
           .post(AuthLinks.refresh, data: {'refreshToken': refresh}).onError(
         (error, stackTrace) {


### PR DESCRIPTION
Changes the baseUrl in the TokenInterceptor to use the production environment instead of the development environment. Additionally, handles the DioException error in the network layer, which was previously unresolved.