### PR TITLE
✨ feat(network): use production base URL

### DIFF
--- a/lib/Data/Network/tools/dio_factory.dart
+++ b/lib/Data/Network/tools/dio_factory.dart
@@ -32,7 +32,7 @@ class DioFactory {
     };
 
     dio.options = BaseOptions(
-      baseUrl: AppLinks.baseUrl,
+      baseUrl: AppLinks.baseUrlProd,
       headers: headers,
       receiveTimeout: timeOut,
       sendTimeout: timeOut,


### PR DESCRIPTION
Changes the base URL used by the Dio HTTP client from the
development URL to the production URL. This ensures that
the application uses the correct server environment when
making network requests.