### PR TITLE
🌱 feat(distribution): clear exam rooms list on init

### DIFF
--- a/lib/domain/controllers/control_mission/distribution_controller.dart
+++ b/lib/domain/controllers/control_mission/distribution_controller.dart
@@ -184,7 +184,6 @@ class DistributionController extends GetxController {
 
   Future<void> getExamRoomByControlMissionId() async {
     isLodingGetExamRooms = true;
-    listExamRoom.clear();
     update(['getExamRoomByControlMissionId']);
 
     final response = await ResponseHandler<ExamRoomsResModel>().getResponse(
@@ -253,6 +252,7 @@ class DistributionController extends GetxController {
   @override
   void onInit() async {
     super.onInit();
+    listExamRoom.clear();
     await Future.wait([
       getControlMissionId(),
       getControlMissionName(),


### PR DESCRIPTION
Clears the `listExamRoom` list on the `DistributionController` init method. This ensures
that the list is empty when the controller is initialized, which can help prevent
any potential issues or inconsistencies with the data displayed in the UI.