### PR TITLE
✨ feat: Add manual workflow dispatch to deploy web app

### DIFF
--- a/.github/workflows/deploy_web_app_to_firebase.yml
+++ b/.github/workflows/deploy_web_app_to_firebase.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - staging
 
+  workflow_dispatch:
+
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a new `workflow_dispatch` trigger to the GitHub Actions workflow
that deploys the web app to Firebase. This allows the workflow to be
manually triggered, in addition to the existing automatic trigger on
the `staging` branch.