### PR TITLE
✨ feat: Add branch input to Firebase deploy workflow

### DIFF
--- a/.github/workflows/deploy_web_app_to_firebase.yml
+++ b/.github/workflows/deploy_web_app_to_firebase.yml
@@ -5,6 +5,10 @@ on:
       - staging
 
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to build"
+        default: staging
 
 jobs:
   build_and_preview:


### PR DESCRIPTION
Add a new branch input to the Firebase deploy workflow to allow
selecting the branch to build and deploy. This provides more
flexibility for deployments, making it easier to deploy changes
from different branches as needed.