### PR TITLE
✨ feat(ci): Simplify deploy workflow

### DIFF
--- a/.github/workflows/deploy_web_app_to_firebase.yml
+++ b/.github/workflows/deploy_web_app_to_firebase.yml
@@ -4,13 +4,6 @@ on:
     branches:
       - staging
 
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to build"
-        default: staging
-        required: true
-
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Simplify the deployment workflow by removing the `workflow_dispatch`
input for the branch to build. The workflow will now only be triggered
on the `staging` branch, reducing complexity and making the deployment
process more straightforward.