### PR TITLE
🔒 feat: Add Firebase files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -44,3 +43,6 @@ app.*.map.json
 
 # IDE - VSCode
 .vscode/*
+
+# Firebase
+.firebase/*


### PR DESCRIPTION
Adds the `.firebase/*` directory to the gitignore file to exclude Firebase
configuration and deployment files from version control. This ensures
sensitive information is not accidentally committed to the repository.