### PR TITLE
✨ feat: Update base URL for production environment

### DIFF
--- a/lib/app/configurations/app_links.dart
+++ b/lib/app/configurations/app_links.dart
@@ -2,7 +2,7 @@ class AppLinks {
   static const baseUrl = 'http://localhost:80/';
   static const baseUrlDev = 'http://localhost:3333/';
   static const baseUrlProd =
-      'https://control-2025-490607372730.us-central1.run.app/';
+      'https://nestjs-control-sql-ip-490607372730.europe-north1.run.app/';
 
   static const baseUrlStaging =
       'https://staging-control-2025-490607372730.us-central1.run.app/';


### PR DESCRIPTION
The changes update the base URL for the production environment from
`https://control-2025-490607372730.us-central1.run.app/` to
`https://nestjs-control-sql-ip-490607372730.europe-north1.run.app/`. This
change is necessary to reflect the new deployment location of the backend
service.