### PR TITLE
✨ feat: Upgrade dependencies and remove unused package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: bidi
-      sha256: "1a7d0c696324b2089f72e7671fd1f1f64fef44c980f3cebc84e803967c597b63"
+      sha256: "9a712c7ddf708f7c41b1923aa83648a3ed44cfd75b04f72d598c45e5be287f9d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.12"
   boolean_selector:
     dependency: transitive
     description:
@@ -477,10 +477,10 @@ packages:
     dependency: transitive
     description:
       name: path_parsing
-      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      sha256: "45f7d6bba1128761de5540f39d5ca000ea8a1f22f06b76b61094a60a2997bd0e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   path_provider:
     dependency: transitive
     description:
@@ -581,10 +581,10 @@ packages:
     dependency: transitive
     description:
       name: qr
-      sha256: "64957a3930367bf97cc211a5af99551d630f2f4625e38af10edd6b19131b64b3"
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   rive:
     dependency: transitive
     description:
@@ -686,14 +686,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
-  transformable_list_view:
-    dependency: "direct main"
-    description:
-      name: transformable_list_view
-      sha256: f228664601e5bb3402b78ca6f523aa51dbfa5cc84c9503e2c9e68a9570ac1c3f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,6 @@ dependencies:
   url_launcher: ^6.3.0
   loading_indicator: ^3.1.1
   lottie: ^3.1.2
-  transformable_list_view: ^0.6.0
   custom_theme:
     git:
       url: https://github.com/Mahmoud-Saeed-Mahmoud/custom_theme.git


### PR DESCRIPTION
This commit upgrades the versions of several dependencies, including `path_parsing`, `qr`, and `bidi`. It also removes the `transformable_list_view` package, which is no longer needed in the project.

The main changes are:

- Upgrade `path_parsing` from `1.0.1` to `1.0.2`
- Upgrade `qr` from `3.0.1` to `3.0.2`
- Upgrade `bidi` from `2.0.10` to `2.0.12`
- Remove the `transformable_list_view` package

These changes are made to ensure the project is using the latest stable versions of the dependencies, which may include bug fixes, performance improvements, or new features. The removal of the `transformable_list_view` package is done to clean up the project and remove unused dependencies.