### PR TITLE
🔒 fix(main): optimize worker count based on device cores

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,10 +20,13 @@ Future<void> main() async {
 
   // workerManager.log = true;
 
-  final numberOfCores = window.navigator.hardwareConcurrency!;
+  final int numberOfCores = window.navigator.hardwareConcurrency!;
+
+  final int numberOfWorkers =
+      (numberOfCores / 5).round() > 2 ? (numberOfCores / 5).round() : 2;
 
   await workerManager.init(
-      isolatesCount: (numberOfCores / 5).round(), dynamicSpawning: true);
+      isolatesCount: numberOfWorkers, dynamicSpawning: true);
 
   await Hive.initFlutter();
   await Future.wait([


### PR DESCRIPTION
Improves the worker count calculation to use a more efficient
algorithm that takes into account the device's hardware
concurrency. The new approach rounds the worker count to the
nearest integer, ensuring a minimum of 2 workers are used
regardless of the device's core count.