### PR TITLE
add-padding-to-exam-rooms-widget

### DIFF
--- a/lib/presentation/views/proctor/widgets/exam_rooms_widget.dart
+++ b/lib/presentation/views/proctor/widgets/exam_rooms_widget.dart
@@ -36,6 +36,7 @@ class ExamRoomsWidget extends GetView<ProctorController> {
               : RepaintBoundary(
                   child: GridView.builder(
                     shrinkWrap: true,
+                    padding: const EdgeInsets.only(right: 20),
                     gridDelegate:
                         const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 6,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: control_system
 description: "Control_System_Web"
 publish_to: "none"
-version: 1.7.11
+version: 1.7.12
 
 environment:
   sdk: ">=3.3.4 <4.0.0"


### PR DESCRIPTION
Here is the pull request description:

Adds padding to the grid view in the ExamRoomsWidget

## Changes
- Adds `EdgeInsets.only(right: 20)` padding to the grid view in the `ExamRoomsWidget` to ensure the last card is not flush with the edge of the screen.
- Bumps the version number in the `pubspec.yaml` file from 1.7.11 to 1.7.12 to reflect the latest changes.

## Why
The previous implementation had the last card in the grid view flush with the edge of the screen, which looked visually unappealing. Adding the right padding ensures the cards have a consistent spacing on all sides.