### PR TITLE
update-cover-sheets-controller

### DIFF
--- a/lib/domain/controllers/batch_documents.dart/cover_sheets_controller.dart
+++ b/lib/domain/controllers/batch_documents.dart/cover_sheets_controller.dart
@@ -616,8 +616,8 @@ class CoversSheetsController extends GetxController {
       selectedItemGrade = items.first;
       updateFilteredList(selectedItemGrade, selectedSubject);
     } else {
-      updateFilteredList(null, selectedSubject);
       selectedItemGrade = null;
+      updateFilteredList(null, selectedSubject);
     }
     update();
   }
@@ -632,8 +632,8 @@ class CoversSheetsController extends GetxController {
       selectedSubject = items.first;
       updateFilteredList(selectedItemGrade, selectedSubject);
     } else {
+      selectedSubject = null;
       updateFilteredList(selectedItemGrade, null);
-      selectedItemGrade = null;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: control_system
 description: "Control_System_Web"
 publish_to: "none"
-version: 1.7.12
+version: 1.7.13
 
 environment:
   sdk: ">=3.3.4 <4.0.0"


### PR DESCRIPTION
Here is a description for the pull request:

Update cover sheets controller to handle null values in filters

This pull request introduces the following changes:

1. Handles null values for `selectedItemGrade` and `selectedSubject` in the `CoversSheetsController`. This ensures that the filtered list is updated correctly when one of the filters is set to null.
2. Bumps the version number in the `pubspec.yaml` file from 1.7.12 to 1.7.13, indicating a new feature or enhancement has been added to the project.