### PR TITLE
✨ feat(ControlMission): Export students' degrees to CSV file

### DIFF
--- a/lib/domain/controllers/control_mission/review_control_mission_controller.dart
+++ b/lib/domain/controllers/control_mission/review_control_mission_controller.dart
@@ -225,6 +225,16 @@ class DetailsAndReviewMissionController extends GetxController {
     return deactivateStudents;
   }
 
+  /// Exports the students' degrees to an Excel (CSV) file and downloads it.
+  ///
+  /// The function generates a CSV file containing students' information such as
+  /// name, grade, class, exam room, and subjects. The subjects' headers are dynamically
+  /// generated based on the subjects associated with the students. The CSV file is
+  /// saved with the name 'students_degrees.csv' in the user's downloads folder.
+  ///
+  /// A success dialog is displayed upon successful export.
+  ///
+  /// [context] is the build context used to show dialogs.
   void exportStudentDegreesToExcel(BuildContext context) {
     List<List<dynamic>> csvData = [];
 


### PR DESCRIPTION
Adds a new feature to the `DetailsAndReviewMissionController` that
allows exporting students' information, including name, grade, class,
exam room, and subjects, to a CSV file. The file is saved in the user's
downloads folder with the name 'students_degrees.csv'. A success dialog
is displayed upon successful export.