### PR TITLE
✨ feat(edit-cover-sheet): update exam mission details

### DIFF
--- a/lib/domain/controllers/batch_documents.dart/edit_cover_controller.dart
+++ b/lib/domain/controllers/batch_documents.dart/edit_cover_controller.dart
@@ -4,6 +4,7 @@ import 'package:awesome_dialog/awesome_dialog.dart';
 import 'package:dio/dio.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:get/get.dart' hide FormData, MultipartFile;
+import 'package:intl/intl.dart';
 import 'package:multi_dropdown/models/value_item.dart';
 
 import '../../../Data/Models/exam_mission/exam_mission_res_model.dart';
@@ -103,6 +104,8 @@ class EditCoverSheetController extends GetxController {
     isLoadingUpdateExamMission = true;
 
     update();
+
+    final DateTime start = DateTime.parse(startTime!);
     bool updateExamMission = false;
     ResponseHandler<ExamMissionResModel> responseHandler = ResponseHandler();
 
@@ -112,6 +115,8 @@ class EditCoverSheetController extends GetxController {
       pdf: pdfUrl,
       period: period,
       endTime: endTime,
+      month: '${start.day} ${DateFormat.MMMM().format(start).toString()}',
+      year: start.year.toString(),
     );
 
     var response = await responseHandler.getResponse(

--- a/lib/presentation/views/batch_documents/widgets/add_new_cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/add_new_cover_widget.dart
@@ -372,7 +372,9 @@ class AddNewCoverWidget extends GetView<CreateCoversSheetsController> {
                           width: 20,
                           style: BorderStyle.solid,
                         ),
-                        borderRadius: BorderRadius.all(Radius.circular(20)),
+                        borderRadius: BorderRadius.all(
+                          Radius.circular(20),
+                        ),
                       ),
                       suffixIcon: const Icon(
                         Icons.date_range_outlined,
@@ -404,32 +406,37 @@ class AddNewCoverWidget extends GetView<CreateCoversSheetsController> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text("Exams Versions :", style: nunitoRegularStyle()),
-              GetBuilder<CreateCoversSheetsController>(builder: (controller) {
-                return Row(
-                  children: [
-                    Text(
-                      '1 Version',
-                      style: TextStyle(
+              GetBuilder<CreateCoversSheetsController>(
+                builder: (controller) {
+                  return Row(
+                    children: [
+                      Text(
+                        '1 Version',
+                        style: TextStyle(
                           color: !controller.is2Version
                               ? Colors.black
-                              : Colors.grey),
-                    ),
-                    Switch.adaptive(
+                              : Colors.grey,
+                        ),
+                      ),
+                      Switch.adaptive(
                         value: controller.is2Version,
                         onChanged: (newValue) {
                           controller.is2Version = newValue;
                           controller.update();
-                        }),
-                    Text(
-                      '2 Versions',
-                      style: TextStyle(
+                        },
+                      ),
+                      Text(
+                        '2 Versions',
+                        style: TextStyle(
                           color: controller.is2Version
                               ? Colors.black
-                              : Colors.grey),
-                    ),
-                  ],
-                );
-              }),
+                              : Colors.grey,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
             ],
           ),
           const SizedBox(
@@ -439,31 +446,34 @@ class AddNewCoverWidget extends GetView<CreateCoversSheetsController> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text("Exams Period :", style: nunitoRegularStyle()),
-              GetBuilder<CreateCoversSheetsController>(builder: (controller) {
-                return Row(
-                  children: [
-                    Text(
-                      'Session One Exams',
-                      style: TextStyle(
-                          color: !controller.isPeriod
-                              ? Colors.black
-                              : Colors.grey),
-                    ),
-                    Switch.adaptive(
-                        value: controller.isPeriod,
-                        onChanged: (newValue) {
-                          controller.isPeriod = newValue;
-                          controller.update();
-                        }),
-                    Text(
-                      'Session Two Exams',
-                      style: TextStyle(
+              GetBuilder<CreateCoversSheetsController>(
+                builder: (controller) {
+                  return Row(
+                    children: [
+                      Text(
+                        'Session One Exams',
+                        style: TextStyle(
                           color:
-                              controller.isPeriod ? Colors.black : Colors.grey),
-                    ),
-                  ],
-                );
-              }),
+                              !controller.isPeriod ? Colors.black : Colors.grey,
+                        ),
+                      ),
+                      Switch.adaptive(
+                          value: controller.isPeriod,
+                          onChanged: (newValue) {
+                            controller.isPeriod = newValue;
+                            controller.update();
+                          }),
+                      Text(
+                        'Session Two Exams',
+                        style: TextStyle(
+                          color:
+                              controller.isPeriod ? Colors.black : Colors.grey,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
             ],
           ),
           GetBuilder<CoversSheetsController>(builder: (controllerCovers) {

--- a/lib/presentation/views/batch_documents/widgets/edit_cover__ad_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/edit_cover__ad_widget.dart
@@ -28,10 +28,12 @@ class EditCoverAdWidget extends GetView<EditCoverSheetController> {
   ExamMissionResModel examMissionObject;
 
   late TextEditingController startTimeController = TextEditingController(
-      text: examMissionObject.startTime == null
-          ? "${examMissionObject.month} ${examMissionObject.year}"
-          : DateFormat('yyyy-MM-dd HH:mm')
-              .format(DateTime.parse(examMissionObject.startTime!)));
+    text: examMissionObject.startTime == null
+        ? "${examMissionObject.month} ${examMissionObject.year}"
+        : DateFormat('yyyy-MM-dd HH:mm').format(
+            DateTime.parse(examMissionObject.startTime!),
+          ),
+  );
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   EditCoverAdWidget(
@@ -74,68 +76,73 @@ class EditCoverAdWidget extends GetView<EditCoverSheetController> {
             height: 20,
           ),
           GetBuilder<EditCoverSheetController>(
-              init: EditCoverSheetController(),
-              dispose: (_) {
-                Get.delete<EditCoverSheetController>();
-              },
-              builder: (_) {
-                if (controller.isLoadingUploadPdf == true) {
-                  return SizedBox(
-                    width: 50,
-                    height: 50,
-                    child: FittedBox(
-                      child: LoadingIndicators.getLoadingIndicator(),
-                    ),
-                  );
-                }
-                return InkWell(
-                  onTap: () {
-                    controller.uploadPdfInExamMission().then((value) {
+            init: EditCoverSheetController(),
+            dispose: (_) {
+              Get.delete<EditCoverSheetController>();
+            },
+            builder: (_) {
+              if (controller.isLoadingUploadPdf == true) {
+                return SizedBox(
+                  width: 50,
+                  height: 50,
+                  child: FittedBox(
+                    child: LoadingIndicators.getLoadingIndicator(),
+                  ),
+                );
+              }
+              return InkWell(
+                onTap: () {
+                  controller.uploadPdfInExamMission().then(
+                    (value) {
                       if (value == true) {
                         MyFlashBar.showSuccess(
                           "Uploaded Successfully",
                           "Success",
                         ).show(Get.key.currentContext!);
                       }
-                    });
-                  },
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Container(
-                        height: 50,
-                        decoration: const BoxDecoration(
-                          borderRadius: BorderRadius.all(
-                            Radius.circular(11),
-                          ),
-                          color: ColorManager.glodenColor,
+                    },
+                  );
+                },
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      height: 50,
+                      decoration: const BoxDecoration(
+                        borderRadius: BorderRadius.all(
+                          Radius.circular(11),
                         ),
-                        child: Center(
-                          child: Text(
-                            "Upload Exam Version A",
-                            style: nunitoRegular.copyWith(
-                              color: Colors.white,
-                              fontSize: 18,
-                            ),
+                        color: ColorManager.glodenColor,
+                      ),
+                      child: Center(
+                        child: Text(
+                          "Upload Exam Version A",
+                          style: nunitoRegular.copyWith(
+                            color: Colors.white,
+                            fontSize: 18,
                           ),
                         ),
                       ),
-                      if (examMissionObject.pdf != null)
-                        SizedBox(
-                          width: Get.width * 0.3,
-                          child: Text("Old Exam :'${examMissionObject.pdf}' ",
-                              style: nunitoRegularStyle()),
+                    ),
+                    if (examMissionObject.pdf != null)
+                      SizedBox(
+                        width: Get.width * 0.3,
+                        child: Text("Old Exam :'${examMissionObject.pdf}' ",
+                            style: nunitoRegularStyle()),
+                      ),
+                    if (controller.isImportedFile == true)
+                      SizedBox(
+                        width: Get.width * 0.3,
+                        child: Text(
+                          "New Exam :'${controller.pdfName}' ",
+                          style: nunitoRegularStyle(),
                         ),
-                      if (controller.isImportedFile == true)
-                        SizedBox(
-                          width: Get.width * 0.3,
-                          child: Text("New Exam :'${controller.pdfName}' ",
-                              style: nunitoRegularStyle()),
-                        )
-                    ],
-                  ),
-                );
-              }),
+                      )
+                  ],
+                ),
+              );
+            },
+          ),
           Form(
             key: _formKey,
             child: Column(
@@ -204,51 +211,53 @@ class EditCoverAdWidget extends GetView<EditCoverSheetController> {
                 const SizedBox(
                   height: 10,
                 ),
-                GetBuilder<EditCoverSheetController>(builder: (_) {
-                  if (controller.selectedStartTime == null) {
-                    return const SizedBox.shrink();
-                  }
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text("End Time:", style: nunitoRegularStyle()),
-                      InkWell(
-                        onTap: () async {
-                          await selectDate(context, isStart: false);
-                          if (controller.selectedEndTime != null) {
-                            endTimeController.text =
-                                DateFormat('yyyy-MM-dd HH:mm')
-                                    .format(controller.selectedEndTime!);
-                            controller.update();
-                          }
-                        },
-                        child: TextFormField(
-                          validator: Validations.requiredValidator,
-                          cursorColor: ColorManager.bgSideMenu,
-                          enabled: false,
-                          style: nunitoRegularStyle(),
-                          controller: endTimeController,
-                          decoration: InputDecoration(
-                            border: const OutlineInputBorder(
-                              borderSide: BorderSide(
-                                color: ColorManager.bgSideMenu,
-                                width: 20,
-                                style: BorderStyle.solid,
+                GetBuilder<EditCoverSheetController>(
+                  builder: (_) {
+                    if (controller.selectedStartTime == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text("End Time:", style: nunitoRegularStyle()),
+                        InkWell(
+                          onTap: () async {
+                            await selectDate(context, isStart: false);
+                            if (controller.selectedEndTime != null) {
+                              endTimeController.text =
+                                  DateFormat('yyyy-MM-dd HH:mm')
+                                      .format(controller.selectedEndTime!);
+                              controller.update();
+                            }
+                          },
+                          child: TextFormField(
+                            validator: Validations.requiredValidator,
+                            cursorColor: ColorManager.bgSideMenu,
+                            enabled: false,
+                            style: nunitoRegularStyle(),
+                            controller: endTimeController,
+                            decoration: InputDecoration(
+                              border: const OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: ColorManager.bgSideMenu,
+                                  width: 20,
+                                  style: BorderStyle.solid,
+                                ),
+                                borderRadius:
+                                    BorderRadius.all(Radius.circular(20)),
                               ),
-                              borderRadius:
-                                  BorderRadius.all(Radius.circular(20)),
+                              suffixIcon: const Icon(
+                                Icons.date_range_outlined,
+                                color: Colors.black,
+                              ),
+                              hintStyle: nunitoRegularStyle(),
                             ),
-                            suffixIcon: const Icon(
-                              Icons.date_range_outlined,
-                              color: Colors.black,
-                            ),
-                            hintStyle: nunitoRegularStyle(),
                           ),
                         ),
-                      ),
-                    ],
-                  );
-                }),
+                      ],
+                    );
+                  },
+                ),
               ],
             ),
           ),
@@ -259,99 +268,108 @@ class EditCoverAdWidget extends GetView<EditCoverSheetController> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text("Exams Period :", style: nunitoRegularStyle()),
-              GetBuilder<EditCoverSheetController>(builder: (controller) {
-                return Row(
-                  children: [
-                    Text(
-                      'Session One Exams',
-                      style: TextStyle(
+              GetBuilder<EditCoverSheetController>(
+                builder: (controller) {
+                  return Row(
+                    children: [
+                      Text(
+                        'Session One Exams',
+                        style: TextStyle(
                           color: examMissionObject.period!
                               ? Colors.black
-                              : Colors.grey),
-                    ),
-                    Switch.adaptive(
+                              : Colors.grey,
+                        ),
+                      ),
+                      Switch.adaptive(
                         value: examMissionObject.period!,
                         onChanged: (newValue) {
                           examMissionObject.period = newValue;
                           controller.update();
-                        }),
-                    Text(
-                      'Session Two Exams',
-                      style: TextStyle(
+                        },
+                      ),
+                      Text(
+                        'Session Two Exams',
+                        style: TextStyle(
                           color: examMissionObject.period!
                               ? Colors.black
-                              : Colors.grey),
-                    ),
-                  ],
-                );
-              }),
+                              : Colors.grey,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
             ],
           ),
-          GetBuilder<EditCoverSheetController>(builder: (_) {
-            if (controller.isLoadingUpdateExamMission ||
-                controller.isLoadingUploadPdf) {
-              return SizedBox(
-                width: 50,
-                height: 50,
-                child: FittedBox(
-                  child: LoadingIndicators.getLoadingIndicator(),
+          GetBuilder<EditCoverSheetController>(
+            builder: (_) {
+              if (controller.isLoadingUpdateExamMission ||
+                  controller.isLoadingUploadPdf) {
+                return SizedBox(
+                  width: 50,
+                  height: 50,
+                  child: FittedBox(
+                    child: LoadingIndicators.getLoadingIndicator(),
+                  ),
+                );
+              }
+              return InkWell(
+                onTap: () {
+                  if (controller.selectedEndTime != null &&
+                      controller.selectedStartTime != null) {
+                    if (controller.selectedEndTime!
+                        .isBefore(controller.selectedStartTime!)) {
+                      MyFlashBar.showError(
+                        "End Time cannot be before Start Time",
+                        "Error",
+                      ).show(Get.key.currentContext!);
+                      return;
+                    }
+                  }
+
+                  if (_formKey.currentState!.validate()) {
+                    controller
+                        .updateExamMission(
+                      endTime: controller.selectedEndTime == null
+                          ? null
+                          : endTimeController.text
+                              .convertDateStringToIso8601String(),
+                      period: examMissionObject.period,
+                      id: examMissionObject.iD!,
+                      startTime: controller.selectedStartTime == null
+                          ? null
+                          : startTimeController.text
+                              .convertDateStringToIso8601String(),
+                      duration: controller.selectedIExamDuration?.value,
+                      pdfUrl: controller.pdfUrl,
+                    )
+                        .then(
+                      (value) {
+                        if (value) {
+                          Get.back();
+                          controller.onClose();
+                          MyFlashBar.showSuccess(
+                            "Exam Cover Sheet Updated Successfully",
+                            "Success",
+                          ).show(Get.key.currentContext!);
+                        }
+                      },
+                    );
+                  }
+                },
+                child: Container(
+                  height: 50,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                      color: ColorManager.bgSideMenu,
+                      borderRadius: BorderRadius.circular(11)),
+                  child: Center(
+                    child: Text("Update", style: nunitoSemiBoldStyle()),
+                  ),
                 ),
               );
-            }
-            return InkWell(
-              onTap: () {
-                if (controller.selectedEndTime != null &&
-                    controller.selectedStartTime != null) {
-                  if (controller.selectedEndTime!
-                      .isBefore(controller.selectedStartTime!)) {
-                    MyFlashBar.showError(
-                      "End Time cannot be before Start Time",
-                      "Error",
-                    ).show(Get.key.currentContext!);
-                    return;
-                  }
-                }
-
-                if (_formKey.currentState!.validate()) {
-                  controller
-                      .updateExamMission(
-                    endTime: controller.selectedEndTime == null
-                        ? null
-                        : endTimeController.text
-                            .convertDateStringToIso8601String(),
-                    period: examMissionObject.period,
-                    id: examMissionObject.iD!,
-                    startTime: controller.selectedStartTime == null
-                        ? null
-                        : startTimeController.text
-                            .convertDateStringToIso8601String(),
-                    duration: controller.selectedIExamDuration?.value,
-                    pdfUrl: controller.pdfUrl,
-                  )
-                      .then((value) {
-                    if (value) {
-                      Get.back();
-                      controller.onClose();
-                      MyFlashBar.showSuccess(
-                        "Exam Cover Sheet Updated Successfully",
-                        "Success",
-                      ).show(Get.key.currentContext!);
-                    }
-                  });
-                }
-              },
-              child: Container(
-                height: 50,
-                width: double.infinity,
-                decoration: BoxDecoration(
-                    color: ColorManager.bgSideMenu,
-                    borderRadius: BorderRadius.circular(11)),
-                child: Center(
-                  child: Text("Update", style: nunitoSemiBoldStyle()),
-                ),
-              ),
-            );
-          })
+            },
+          )
         ],
       ),
     );

--- a/lib/presentation/views/batch_documents/widgets/edit_cover_widget.dart
+++ b/lib/presentation/views/batch_documents/widgets/edit_cover_widget.dart
@@ -178,53 +178,59 @@ class EditCoverWidget extends GetView<EditCoverSheetController> {
               }),
             ],
           ),
-          GetBuilder<EditCoverSheetController>(builder: (_) {
-            if (controller.isLoadingUpdateExamMission ||
-                controller.isLoadingUploadPdf) {
-              return SizedBox(
-                width: 50,
-                height: 50,
-                child: FittedBox(
-                  child: LoadingIndicators.getLoadingIndicator(),
+          GetBuilder<EditCoverSheetController>(
+            builder: (_) {
+              if (controller.isLoadingUpdateExamMission ||
+                  controller.isLoadingUploadPdf) {
+                return SizedBox(
+                  width: 50,
+                  height: 50,
+                  child: FittedBox(
+                    child: LoadingIndicators.getLoadingIndicator(),
+                  ),
+                );
+              }
+              return InkWell(
+                onTap: () {
+                  controller
+                      .updateExamMissionByOffice(
+                    year: selectedYear == null
+                        ? examMissionObject.year!
+                        : selectedYear!,
+                    month: selectedMonth == null
+                        ? examMissionObject.month!
+                        : '${selectedDay!} ${selectedMonth!}',
+                    period: examMissionObject.period,
+                    id: examMissionObject.iD!,
+                    duration: controller.selectedIExamDuration?.value,
+                  )
+                      .then((value) {
+                    if (value) {
+                      Get.back();
+                      MyFlashBar.showSuccess(
+                        "Exam Cover Sheet Updated Successfully",
+                        "Success",
+                      ).show(Get.key.currentContext!);
+                    }
+                  });
+                },
+                child: Container(
+                  height: 50,
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: ColorManager.bgSideMenu,
+                    borderRadius: BorderRadius.circular(11),
+                  ),
+                  child: Center(
+                    child: Text(
+                      "Update",
+                      style: nunitoSemiBoldStyle(),
+                    ),
+                  ),
                 ),
               );
-            }
-            return InkWell(
-              onTap: () {
-                controller
-                    .updateExamMissionByOffice(
-                  year: selectedYear == null
-                      ? examMissionObject.year!
-                      : selectedYear!,
-                  month: selectedMonth == null
-                      ? examMissionObject.month!
-                      : '${selectedDay!} ${selectedMonth!}',
-                  period: examMissionObject.period,
-                  id: examMissionObject.iD!,
-                  duration: controller.selectedIExamDuration?.value,
-                )
-                    .then((value) {
-                  if (value) {
-                    Get.back();
-                    MyFlashBar.showSuccess(
-                      "Exam Cover Sheet Updated Successfully",
-                      "Success",
-                    ).show(Get.key.currentContext!);
-                  }
-                });
-              },
-              child: Container(
-                height: 50,
-                width: double.infinity,
-                decoration: BoxDecoration(
-                    color: ColorManager.bgSideMenu,
-                    borderRadius: BorderRadius.circular(11)),
-                child: Center(
-                  child: Text("Update", style: nunitoSemiBoldStyle()),
-                ),
-              ),
-            );
-          })
+            },
+          )
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: control_system
 description: "Control_System_Web"
 publish_to: "none"
-version: 1.7.18
+version: 1.7.19
 
 environment:
   sdk: ">=3.3.4 <4.0.0"


### PR DESCRIPTION
This commit updates the `EditCoverSheetController` to handle the changes in the `EditCoverAdWidget` and `EditCoverWidget` views.

The main changes include:

- Adding the `month` and `year` properties to the `ExamMissionResModel` to better handle the exam start time display.
- Updating the `updateExamMission` method to include the `month` and `year` properties when updating the exam mission.
- Improving the handling of the start and end time selection in the `EditCoverAdWidget`.
- Updating the loading and update logic in the `EditCoverWidget` and `EditCoverAdWidget` to provide a better user experience.

These changes ensure that the exam mission details are properly updated and displayed in the corresponding views.